### PR TITLE
gh-3: Harden event-day readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,19 @@ The Playwright suite covers:
 - finalization
 - public finalized lock state
 - manager XLSX export
+- anonymous cross-device freshness after another judge updates a score
+
+Cheap event-day readiness checks:
+
+```bash
+pnpm test tests/readiness.integration.test.ts
+pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 250
+```
+
+These checks prove two different things:
+
+- `tests/readiness.integration.test.ts` simulates 50 concurrent judges scoring a round in waves against the real Prisma-backed vote logic.
+- `readiness:public` sends 250 public scoreboard requests with 50-way concurrency to confirm the live site stays responsive under the expected spectator load without requiring a paid load-testing service.
 
 Proof notes live in [proof.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/proof.md).
 

--- a/components/results-dashboard.tsx
+++ b/components/results-dashboard.tsx
@@ -65,12 +65,40 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
   const [authDialogOpen, setAuthDialogOpen] = React.useState(false);
   const uploadInputRef = React.useRef<HTMLInputElement>(null);
   const copy = statusCopy(snapshot.status);
+  const autoRefreshIntervalMs = snapshot.status === "OPEN" ? 5000 : 15000;
+  const autoRefreshPaused =
+    Boolean(selectedEntry) ||
+    authDialogOpen ||
+    uploadState.status === "uploading" ||
+    pendingAction;
 
   function refreshBoard() {
     startTransition(() => {
       router.refresh();
     });
   }
+
+  React.useEffect(() => {
+    if (autoRefreshPaused) return;
+
+    let intervalId: number | null = null;
+    const refreshIfVisible = () => {
+      if (document.visibilityState !== "visible" || !window.navigator.onLine) return;
+      startTransition(() => {
+        router.refresh();
+      });
+    };
+
+    intervalId = window.setInterval(refreshIfVisible, autoRefreshIntervalMs);
+    window.addEventListener("focus", refreshIfVisible);
+    document.addEventListener("visibilitychange", refreshIfVisible);
+
+    return () => {
+      if (intervalId != null) window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshIfVisible);
+      document.removeEventListener("visibilitychange", refreshIfVisible);
+    };
+  }, [autoRefreshIntervalMs, autoRefreshPaused, router, startTransition]);
 
   async function postJson(url: string) {
     const response = await fetch(url, {
@@ -189,6 +217,9 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
               </div>
               <Progress value={snapshot.progress.percentage} />
               <p className="text-sm leading-7 text-muted-foreground">{snapshot.progress.helperText}</p>
+              <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                Board refreshes automatically every {Math.round(autoRefreshIntervalMs / 1000)} seconds while this tab is active.
+              </p>
               <div className="grid gap-3 sm:grid-cols-3">
                 <div className="rounded-[1.5rem] bg-radix-gray-a-3 p-4">
                   <div className="eyebrow">Entries</div>

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -96,6 +96,7 @@ Every uploaded team-member email is stored against that project.
 - The manager clicks `Begin voting`.
 - Authenticated judges can vote.
 - Public viewers can keep watching the board update live.
+- Active tabs refresh automatically every 5 seconds during judging, and inactive tabs refresh again when they regain focus.
 
 ### Finalized
 
@@ -154,6 +155,19 @@ Production validation:
 ```bash
 E2E_BASE_URL=https://vote.rajeevg.com E2E_JUDGE_AUTH_MODE=ticket pnpm test:e2e
 ```
+
+Event-day readiness validation:
+
+```bash
+pnpm test tests/readiness.integration.test.ts
+pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 250
+```
+
+What that readiness pack means in practice:
+
+- The write path has been exercised with 50 concurrent judges across a full round.
+- The public scoreboard has been probed at 50-way concurrency without paying for an external load platform.
+- Cross-device freshness is covered by browser proof, where an anonymous viewer sees a judge's updated score without manually reloading.
 
 Manual production proof also matters for auth:
 

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -113,6 +113,7 @@ Self-vote blocking is derived from normalized email equality between the signed-
 - Authenticated judges can vote.
 - A judge becomes part of the progress denominator the moment they cast their first score.
 - A judge can edit their score for the same project; the vote row is updated in place.
+- Active scoreboard tabs auto-refresh every 5 seconds during judging, and focused tabs also refresh on visibility or focus return.
 
 ### `FINALIZED`
 
@@ -151,3 +152,9 @@ This keeps the rule coherent without introducing a separate roster-management sy
   - support keyboard-first scoring
   - announce feedback with live regions
   - remain usable on mobile
+
+## Event-day readiness notes
+
+- The production readiness target is a room-sized session of roughly 50 judges or viewers at once, not a viral public launch.
+- The repo includes a cheap public-read probe at `pnpm readiness:public` so the live site can be checked before the event without extra vendor spend.
+- Concurrent write readiness is covered in `tests/readiness.integration.test.ts`, which runs the real vote logic with 50 concurrent judges in project-by-project waves.

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -44,6 +44,34 @@ Result:
 
 - Pass
 
+## Event-day readiness proof
+
+Date: `2026-03-23`
+
+Goal:
+
+- Verify the app is credible for a room-sized judging session without paying for heavyweight load tooling
+
+Command set:
+
+```bash
+pnpm test tests/readiness.integration.test.ts
+pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 250
+```
+
+What this covers:
+
+- `tests/readiness.integration.test.ts` exercises the real Prisma-backed voting rules with 50 concurrent judges voting in project-by-project waves.
+- The readiness test also proves the self-vote denominator stays correct when some judges are blocked from some entries.
+- `readiness:public` applies 50 concurrent public GETs and 250 total scoreboard requests against production to catch obvious response degradation or broken HTML under spectator traffic.
+- The main Playwright journey now additionally proves that one device sees another device's score change without a manual reload.
+
+Limitations:
+
+- This is a practical readiness pass, not a full synthetic internet-scale soak test.
+- It does not emulate 50 fully interactive browsers continuously animating at once.
+- It does provide strong evidence for the actual risks that matter here: concurrent voting writes, public read pressure, cross-device freshness, and the mobile/desktop user journey.
+
 ## Production proof
 
 Date: `2026-03-23`

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "db:push": "prisma db push",
     "clerk:ticket": "node scripts/create-clerk-sign-in-token.mjs",
     "proof:workbook": "node scripts/generate-proof-workbook.mjs",
+    "readiness:public": "node scripts/load-scoreboard.mjs",
     "test:e2e": "playwright test",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/scripts/load-scoreboard.mjs
+++ b/scripts/load-scoreboard.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import process from "node:process";
+import { performance } from "node:perf_hooks";
+
+function parseArg(flag, fallback) {
+  const index = process.argv.indexOf(flag);
+  if (index === -1) return fallback;
+  const value = process.argv[index + 1];
+  return value ?? fallback;
+}
+
+const url = parseArg("--url", "https://vote.rajeevg.com");
+const concurrency = Number(parseArg("--concurrency", "50"));
+const requests = Number(parseArg("--requests", "250"));
+
+if (!Number.isFinite(concurrency) || concurrency <= 0 || !Number.isFinite(requests) || requests <= 0) {
+  console.error("Concurrency and requests must be positive numbers.");
+  process.exit(1);
+}
+
+const durations = [];
+const statusCounts = new Map();
+let completed = 0;
+let failures = 0;
+let pointer = 0;
+
+async function runOne(requestNumber) {
+  const startedAt = performance.now();
+
+  try {
+    const response = await fetch(url, {
+      redirect: "follow"
+    });
+    const body = await response.text();
+    const elapsedMs = performance.now() - startedAt;
+
+    durations.push(elapsedMs);
+    statusCounts.set(response.status, (statusCounts.get(response.status) ?? 0) + 1);
+
+    if (!body.includes("Hackathon scoreboard")) {
+      failures += 1;
+      console.error(`Request ${requestNumber} returned ${response.status} without the scoreboard heading.`);
+    }
+  } catch (error) {
+    failures += 1;
+    console.error(`Request ${requestNumber} failed:`, error instanceof Error ? error.message : error);
+  } finally {
+    completed += 1;
+  }
+}
+
+async function worker() {
+  while (pointer < requests) {
+    pointer += 1;
+    const requestNumber = pointer;
+    await runOne(requestNumber);
+  }
+}
+
+await Promise.all(Array.from({ length: concurrency }, () => worker()));
+
+durations.sort((left, right) => left - right);
+
+function percentile(value) {
+  if (!durations.length) return 0;
+  const index = Math.min(durations.length - 1, Math.floor((value / 100) * durations.length));
+  return durations[index];
+}
+
+console.log(
+  JSON.stringify(
+    {
+      url,
+      concurrency,
+      requests,
+      completed,
+      failures,
+      p50Ms: Number(percentile(50).toFixed(2)),
+      p95Ms: Number(percentile(95).toFixed(2)),
+      p99Ms: Number(percentile(99).toFixed(2)),
+      maxMs: Number((durations.at(-1) ?? 0).toFixed(2)),
+      statuses: Object.fromEntries(statusCounts)
+    },
+    null,
+    2
+  )
+);

--- a/tests/e2e/single-screen-voting.spec.ts
+++ b/tests/e2e/single-screen-voting.spec.ts
@@ -261,6 +261,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await openVoteDialog(anonymousPage, "Aurora Atlas");
     await expect(anonymousPage.getByText("Sign in and score this project")).toBeVisible();
     await expect(anonymousPage.getByTestId("submit-vote")).toHaveCount(0);
+    await anonymousPage.getByRole("button", { name: "Close" }).click();
   });
 
   await test.step("A judge signs in by email code and submits keyboard-friendly modal votes", async () => {
@@ -294,6 +295,11 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await expect(signalBloomRow).toContainText("1 vote");
     await expect(signalBloomRow).toContainText("9");
     await expect(signalBloomAction).toContainText("Update");
+    await expect(
+      anonymousPage
+        .getByTestId("scoreboard-row-signal-bloom")
+        .nth(activeResponsiveIndex(testInfo.project.name))
+    ).toContainText("9", { timeout: 12000 });
 
     await openVoteDialog(judgePage, "Harbor Pulse");
     await saveVote(judgePage, 6);

--- a/tests/readiness.integration.test.ts
+++ b/tests/readiness.integration.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { submitJudgeVote } from "@/lib/competition";
+import { deriveCompetitionSnapshot } from "@/lib/competition-logic";
+import { COMPETITION_STATE_ID, MANAGER_EMAIL } from "@/lib/constants";
+import { prisma } from "@/lib/prisma";
+
+const anonymousViewer = {
+  clerkUserId: null,
+  email: null,
+  isAuthenticated: false,
+  isManager: false
+} as const;
+
+async function resetDatabase() {
+  await prisma.vote.deleteMany();
+  await prisma.entryTeamEmail.deleteMany();
+  await prisma.entry.deleteMany();
+  await prisma.competitionState.upsert({
+    where: { id: COMPETITION_STATE_ID },
+    update: {
+      votingStatus: "PREPARING",
+      startedAt: null,
+      finalizedAt: null,
+      managerEmail: MANAGER_EMAIL
+    },
+    create: {
+      id: COMPETITION_STATE_ID,
+      votingStatus: "PREPARING",
+      startedAt: null,
+      finalizedAt: null,
+      managerEmail: MANAGER_EMAIL
+    }
+  });
+}
+
+async function openVotingRound() {
+  await prisma.competitionState.update({
+    where: { id: COMPETITION_STATE_ID },
+    data: {
+      votingStatus: "OPEN",
+      startedAt: new Date("2026-03-23T12:00:00.000Z"),
+      finalizedAt: null
+    }
+  });
+}
+
+async function createEntries({
+  entryCount,
+  blockedJudges = []
+}: {
+  entryCount: number;
+  blockedJudges?: string[];
+}) {
+  const entries = [];
+
+  for (let index = 0; index < entryCount; index += 1) {
+    const blockedJudge = blockedJudges[index] ?? `team-${index + 1}@example.com`;
+    const entry = await prisma.entry.create({
+      data: {
+        slug: `readiness-entry-${index + 1}`,
+        projectName: `Readiness Entry ${index + 1}`,
+        teamName: `Team ${index + 1}`,
+        summary: `Synthetic readiness entry ${index + 1}.`,
+        teamEmails: {
+          create: [{ email: blockedJudge }]
+        }
+      }
+    });
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+async function getSnapshot() {
+  const entries = await prisma.entry.findMany({
+    include: {
+      teamEmails: true,
+      votes: {
+        orderBy: {
+          updatedAt: "desc"
+        }
+      }
+    }
+  });
+
+  return deriveCompetitionSnapshot({
+    status: "OPEN",
+    startedAt: new Date("2026-03-23T12:00:00.000Z"),
+    finalizedAt: null,
+    entries,
+    viewer: anonymousViewer
+  });
+}
+
+async function submitVotingWave({
+  entries,
+  judges,
+  scoreOffset = 0,
+  blockedJudgeByEntry = []
+}: {
+  entries: Awaited<ReturnType<typeof createEntries>>;
+  judges: string[];
+  scoreOffset?: number;
+  blockedJudgeByEntry?: string[];
+}) {
+  for (const [entryIndex, entry] of entries.entries()) {
+    const results = await Promise.allSettled(
+      judges
+        .filter((judgeEmail) => blockedJudgeByEntry[entryIndex] !== judgeEmail)
+        .map((judgeEmail, judgeIndex) =>
+          submitJudgeVote({
+            entryId: entry.id,
+            judgeEmail,
+            judgeUserId: `user_${judgeIndex + 1}`,
+            score: (judgeIndex + entryIndex + scoreOffset) % 11
+          })
+        )
+    );
+
+    const rejectionMessages = results
+      .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+      .map((result) => (result.reason instanceof Error ? result.reason.message : String(result.reason)));
+
+    expect(rejectionMessages).toEqual([]);
+  }
+}
+
+describe("event-day readiness", () => {
+  beforeEach(async () => {
+    await resetDatabase();
+    await openVotingRound();
+  });
+
+  afterEach(async () => {
+    await resetDatabase();
+  });
+
+  it(
+    "handles 50 concurrent judges scoring 4 entries without missing votes",
+    async () => {
+      const entries = await createEntries({ entryCount: 4 });
+      const judges = Array.from({ length: 50 }, (_, index) => `judge-${index + 1}@example.com`);
+
+      await submitVotingWave({
+        entries,
+        judges
+      });
+
+      expect(await prisma.vote.count()).toBe(200);
+
+      const snapshot = await getSnapshot();
+      expect(snapshot.progress.participatingJudgeCount).toBe(50);
+      expect(snapshot.progress.entryCount).toBe(4);
+      expect(snapshot.progress.castVotes).toBe(200);
+      expect(snapshot.progress.expectedVotes).toBe(200);
+      expect(snapshot.progress.percentage).toBe(100);
+      expect(snapshot.progress.isComplete).toBe(true);
+    },
+    30000
+  );
+
+  it(
+    "keeps completion accurate when self-vote exclusions remove entries from the denominator",
+    async () => {
+      const judges = Array.from({ length: 50 }, (_, index) => `judge-${index + 1}@example.com`);
+      const blockedJudges = judges.slice(0, 5);
+      const entries = await createEntries({
+        entryCount: 5,
+        blockedJudges
+      });
+
+      await submitVotingWave({
+        entries,
+        judges,
+        scoreOffset: 3,
+        blockedJudgeByEntry: blockedJudges
+      });
+
+      expect(await prisma.vote.count()).toBe(245);
+
+      const snapshot = await getSnapshot();
+      expect(snapshot.progress.participatingJudgeCount).toBe(50);
+      expect(snapshot.progress.entryCount).toBe(5);
+      expect(snapshot.progress.castVotes).toBe(245);
+      expect(snapshot.progress.expectedVotes).toBe(245);
+      expect(snapshot.progress.percentage).toBe(100);
+      expect(snapshot.progress.isComplete).toBe(true);
+    },
+    30000
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     globals: true,
     exclude: ["tests/e2e/**", "node_modules/**", ".next/**"],
     setupFiles: ["./tests/setup.ts"],
+    fileParallelism: false,
     sequence: {
       concurrent: false
     }


### PR DESCRIPTION
## Summary\n- add active-tab scoreboard auto-refresh during open judging so the public board stays fresh across devices\n- add readiness integration tests for 50 concurrent judges and self-vote-adjusted completion\n- add a cheap production public-read load probe and document the readiness workflow\n\n## Why\nThe app needed stronger evidence that it will behave well in a real judging room without relying on expensive load tooling. This slice focuses on the risks that matter most on event day: concurrent scoring, public scoreboard freshness, and mobile/desktop journey quality.\n\n## Validation\n- pnpm check\n- pnpm build\n- pnpm test tests/votes.integration.test.ts\n- pnpm test tests/readiness.integration.test.ts (repeated 3x)\n- pnpm test\n- pnpm test:e2e\n\nCloses #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scoreboard now auto-refreshes every 5 seconds during voting, pausing when tabs lose focus and resuming automatically
  * Added event-day readiness validation commands for load testing and concurrent judge scenarios

* **Tests**
  * New integration test for concurrent judge voting under production conditions
  * Enhanced e2e tests to validate cross-device scoreboard freshness without manual reload

* **Documentation**
  * Updated with auto-refresh behavior details and event-day readiness validation instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->