### PR TITLE
gh-6: fix manager workbook dry-run flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The app keeps the visual language of the original results dashboard, but the pro
 - Automatic self-vote blocking from uploaded team-member emails
 - Live judging progress
 - Manager-only finalization and finalized XLSX export
+- Manager-only reset button for repeatable dry runs
 - Light and dark mode
 - Flows walkthrough mount via `flows.sh`
 
@@ -116,6 +117,7 @@ Only that account can:
 
 - download the workbook template
 - upload a workbook
+- reset the round back to an empty state
 - begin voting
 - finalize the round
 - export finalized results

--- a/app/api/competition/reset/route.ts
+++ b/app/api/competition/reset/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+
+import { requireManagerIdentity } from "@/lib/auth";
+import { resetCompetitionRound } from "@/lib/competition";
+
+export const runtime = "nodejs";
+
+export async function POST() {
+  try {
+    await requireManagerIdentity();
+    await resetCompetitionRound();
+
+    return NextResponse.json(
+      {
+        ok: true
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Competition reset failed."
+      },
+      { status: 403 }
+    );
+  }
+}

--- a/components/results-dashboard.tsx
+++ b/components/results-dashboard.tsx
@@ -10,6 +10,7 @@ import {
   FolderUp,
   LoaderCircle,
   Play,
+  RotateCcw,
   ShieldCheck,
   Trophy
 } from "lucide-react";
@@ -65,6 +66,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
   const [authDialogOpen, setAuthDialogOpen] = React.useState(false);
   const uploadInputRef = React.useRef<HTMLInputElement>(null);
   const copy = statusCopy(snapshot.status);
+  const isEmpty = snapshot.entries.length === 0;
   const autoRefreshIntervalMs = snapshot.status === "OPEN" ? 5000 : 15000;
   const autoRefreshPaused =
     Boolean(selectedEntry) ||
@@ -245,10 +247,14 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
             <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
               <div>
                 <div className="eyebrow">Scoreboard</div>
-                <h2 className="font-display text-2xl font-black">Every project, one board</h2>
+                <h2 className="font-display text-2xl font-black">
+                  {isEmpty ? "Upload once, then the board comes alive" : "Every project, one board"}
+                </h2>
               </div>
               <div className="text-sm text-muted-foreground">
-                Click any row to vote or review why that project is locked.
+                {isEmpty
+                  ? "No placeholder projects are shown. The board stays empty until the manager uploads the workbook."
+                  : "Click any row to vote or review why that project is locked."}
               </div>
             </div>
             <ResultsScoreboardTable
@@ -275,7 +281,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                         XLSX workflow
                       </div>
                       <p className="mt-2 text-sm leading-7 text-muted-foreground">
-                        Download the template, fill one row per project, keep project names unique, and include at least one team email per row.
+                        Download the template, fill one row per project, keep project names unique, and include at least one team email per row. The live board is driven entirely by what you upload here.
                       </p>
                       <div className="mt-4 flex flex-wrap gap-3">
                         <Button asChild size="sm" variant="outline">
@@ -287,11 +293,48 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                         {snapshot.canDownloadFinalizedExport ? (
                           <Button asChild size="sm">
                             <a data-testid="manager-export-results" href="/api/export">
-                              Export finalized scores
-                              <ArrowUpRight className="h-4 w-4" />
-                            </a>
-                          </Button>
-                        ) : null}
+                            Export finalized scores
+                            <ArrowUpRight className="h-4 w-4" />
+                          </a>
+                        </Button>
+                      ) : null}
+                        <Button
+                          data-testid="manager-reset-round"
+                          disabled={!snapshot.canResetRound || pendingAction || uploadState.status === "uploading"}
+                          onClick={() => {
+                            if (
+                              !window.confirm(
+                                "Reset the round and remove the current workbook, votes, and judging state?"
+                              )
+                            ) {
+                              return;
+                            }
+
+                            void (async () => {
+                              try {
+                                setActionMessage(null);
+                                setUploadState({
+                                  status: "idle",
+                                  message: null,
+                                  issues: []
+                                });
+                                await postJson("/api/competition/reset");
+                                setActionMessage("Competition reset. Upload a fresh workbook to start the next dry run.");
+                                refreshBoard();
+                              } catch (error) {
+                                setActionMessage(
+                                  error instanceof Error ? error.message : "We could not reset the round."
+                                );
+                              }
+                            })();
+                          }}
+                          size="sm"
+                          type="button"
+                          variant="destructive"
+                        >
+                          <RotateCcw className="h-4 w-4" />
+                          Reset dry run
+                        </Button>
                       </div>
                     </div>
 
@@ -342,7 +385,9 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                           <div>
                             <div className="font-semibold text-foreground">Drag, drop, or choose a workbook</div>
                             <div className="text-sm text-muted-foreground">
-                              Upload is only available before voting begins.
+                              {snapshot.canUploadSheet
+                                ? "Upload is available now."
+                                : "Upload unlocks again after you reset the round back to manager setup."}
                             </div>
                           </div>
                         </div>
@@ -366,6 +411,12 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                     {uploadState.message ? (
                       <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4 text-sm text-muted-foreground">
                         {uploadState.message}
+                      </div>
+                    ) : null}
+
+                    {snapshot.viewer.isManager && isEmpty && uploadState.status === "idle" ? (
+                      <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4 text-sm leading-7 text-muted-foreground">
+                        No workbook is loaded right now. Download the blank template, fill it in, and upload it here to populate the board.
                       </div>
                     ) : null}
 

--- a/components/results-scoreboard-table.tsx
+++ b/components/results-scoreboard-table.tsx
@@ -35,6 +35,26 @@ export function ResultsScoreboardTable({
   viewer,
   onSelectEntry
 }: ResultsScoreboardTableProps) {
+  if (entries.length === 0) {
+    return (
+      <div className="glass-panel rounded-[2rem] border border-border/80 p-8">
+        <div className="eyebrow">Workbook-driven board</div>
+        <h3 className="mt-3 font-display text-2xl font-black text-foreground">No projects loaded yet</h3>
+        <p className="mt-4 max-w-2xl text-sm leading-7 text-muted-foreground">
+          The public scoreboard appears here after the manager uploads the judging workbook. Until then, the app stays empty on purpose so the event board is driven entirely by real XLSX content.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">No placeholder projects</span>
+          <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+            {viewer.isManager && status === "PREPARING"
+              ? "Upload a workbook to begin"
+              : "Waiting for manager workbook upload"}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <>
       <div className="space-y-3 md:hidden">

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -23,6 +23,7 @@ The app is intentionally a single-screen product.
 - Only this user can:
   - download the workbook template
   - upload a workbook
+  - reset the round to an empty workbook-driven state
   - begin voting
   - finalize the round
   - export finalized scores
@@ -70,6 +71,7 @@ Supported template columns:
 
 Important rules:
 
+- The downloaded template is intentionally blank. There are no seeded demo or placeholder projects.
 - `Project Name` must be unique.
 - Each row must contain at least one team email.
 - Unknown non-email columns are tolerated and stored as metadata.
@@ -88,8 +90,14 @@ Every uploaded team-member email is stored against that project.
 ### Preparing
 
 - Public scoreboard is visible.
-- Manager can download the template and upload/update the workbook.
+- Manager can download the blank template and upload or replace the workbook.
 - Voting controls stay locked.
+
+### Resetting for another dry run
+
+- The manager can click `Reset dry run` from the same screen.
+- Reset clears uploaded entries, stored team emails, votes, and the current judging lifecycle state.
+- After reset, the board returns to an intentionally empty state until a new workbook is uploaded.
 
 ### Open
 
@@ -132,12 +140,13 @@ See [/Users/rajeev/Code/hackathon-voting-prototype/prisma/schema.prisma](/Users/
 2. Download the template from `/`.
 3. Fill one row per project and keep project names unique.
 4. Upload the XLSX from the manager panel.
-5. Confirm all entries appear on the scoreboard.
-6. Click `Begin voting` once the judges are ready.
-7. Ask judges to sign in once and vote from the modal.
-8. Watch the progress card until completion reaches `100%`.
-9. Click `Finalize`.
-10. Export the finalized workbook.
+5. Confirm all entries appear on the scoreboard and that there is no placeholder content.
+6. If you need a clean rehearsal, click `Reset dry run`, then upload again.
+7. Click `Begin voting` once the judges are ready.
+8. Ask judges to sign in once and vote from the modal.
+9. Watch the progress card until completion reaches `100%`.
+10. Click `Finalize`.
+11. Export the finalized workbook.
 
 ## Proof and verification
 

--- a/lib/competition-logic.ts
+++ b/lib/competition-logic.ts
@@ -62,6 +62,7 @@ export type CompetitionSnapshot = {
   canUploadSheet: boolean;
   canBeginVoting: boolean;
   canFinalize: boolean;
+  canResetRound: boolean;
   canDownloadFinalizedExport: boolean;
 };
 
@@ -249,6 +250,7 @@ export function deriveCompetitionSnapshot({
     canUploadSheet: viewer.isManager && status === "PREPARING",
     canBeginVoting: viewer.isManager && status === "PREPARING" && entries.length > 0,
     canFinalize: viewer.isManager && status === "OPEN" && progress.isComplete,
+    canResetRound: viewer.isManager && (entries.length > 0 || status !== "PREPARING"),
     canDownloadFinalizedExport: viewer.isManager && status === "FINALIZED"
   };
 }

--- a/lib/competition.ts
+++ b/lib/competition.ts
@@ -14,6 +14,7 @@ const anonymousViewer = {
   isAuthenticated: false,
   isManager: false
 } as const;
+const shouldUsePublicSnapshotCache = process.env.NODE_ENV === "production";
 
 async function ensureCompetitionState() {
   const existingState = await withPrismaRetry(() =>
@@ -113,7 +114,7 @@ const getCachedPublicCompetitionSnapshot = unstable_cache(
 
 export async function getCompetitionSnapshot() {
   const viewer = await getViewerIdentity();
-  if (!viewer.isAuthenticated) {
+  if (!viewer.isAuthenticated && shouldUsePublicSnapshotCache) {
     return getCachedPublicCompetitionSnapshot();
   }
 
@@ -204,6 +205,28 @@ export async function beginVotingRound() {
         startedAt: new Date(),
         finalizedAt: null
       }
+    })
+  );
+
+  safeRevalidateHome();
+}
+
+export async function resetCompetitionRound() {
+  await ensureCompetitionState();
+
+  await withPrismaRetry(() =>
+    prisma.$transaction(async (tx) => {
+      await tx.vote.deleteMany();
+      await tx.entryTeamEmail.deleteMany();
+      await tx.entry.deleteMany();
+      await tx.competitionState.update({
+        where: { id: COMPETITION_STATE_ID },
+        data: {
+          votingStatus: "PREPARING",
+          startedAt: null,
+          finalizedAt: null
+        }
+      });
     })
   );
 

--- a/lib/xlsx.ts
+++ b/lib/xlsx.ts
@@ -148,19 +148,7 @@ export function buildTemplateWorkbook() {
     ...Array.from({ length: MAX_TEAM_EMAIL_COLUMNS }, (_, index) => `Team Member ${index + 1} Email`),
     "Optional Note"
   ];
-  const entryData = [
-    entryHeaders,
-    [
-      "Aurora Atlas",
-      "Team North Star",
-      "An AI assistant for hackathon project triage.",
-      "founder@example.com",
-      "designer@example.com",
-      "",
-      "",
-      "Extra columns are allowed and will be preserved as metadata."
-    ]
-  ];
+  const entryData = [entryHeaders];
 
   const instructionsData = [
     ["How to use this workbook"],

--- a/tests/e2e/single-screen-voting.spec.ts
+++ b/tests/e2e/single-screen-voting.spec.ts
@@ -220,6 +220,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
   await test.step("Anonymous visitors can see the board but not manager tools", async () => {
     await anonymousPage.goto("/");
     await expect(anonymousPage.getByRole("heading", { name: "Hackathon scoreboard" })).toBeVisible();
+    await expect(anonymousPage.getByText("No projects loaded yet")).toBeVisible();
     await expect(anonymousPage.getByTestId("manager-download-template")).toHaveCount(0);
     await expect(anonymousPage.getByTestId("manager-upload-dropzone")).toHaveCount(0);
     await takeShot(anonymousPage, testInfo.outputPath("public-before-setup.png"));
@@ -234,11 +235,11 @@ test("manager, judges, and public users complete the single-screen voting flow",
     ]);
     expect(templateDownload.suggestedFilename()).toContain("hackathon-voting-template");
 
-    const [fileChooser] = await Promise.all([
+    const [dropzoneFileChooser] = await Promise.all([
       managerPage.waitForEvent("filechooser"),
-      managerPage.getByTestId("manager-upload-button").click()
+      managerPage.getByTestId("manager-upload-dropzone").click()
     ]);
-    await fileChooser.setFiles(workbookPath);
+    await dropzoneFileChooser.setFiles(workbookPath);
     await expect(managerPage.getByText("Imported 3 projects.")).toBeVisible();
     const rowIndex = activeResponsiveIndex(testInfo.project.name);
     await expect(managerPage.getByTestId("scoreboard-row-aurora-atlas").nth(rowIndex)).toBeVisible();
@@ -365,6 +366,30 @@ test("manager, judges, and public users complete the single-screen voting flow",
     expect(hasHorizontalOverflow).toBe(false);
 
     await takeShot(anonymousPage, testInfo.outputPath("public-finalized.png"));
+  });
+
+  await test.step("Manager can reset the round and return to an empty workbook-driven state", async () => {
+    await managerPage.goto("/");
+    managerPage.once("dialog", (dialog) => void dialog.accept());
+    await managerPage.getByTestId("manager-reset-round").click();
+    await expect(managerPage.getByText("Competition reset. Upload a fresh workbook to start the next dry run.")).toBeVisible();
+    await expect(managerPage.getByText("No projects loaded yet")).toBeVisible();
+    await expect(managerPage.getByTestId("manager-begin-voting")).toBeDisabled();
+    await expect(managerPage.getByTestId("manager-upload-button")).toBeEnabled();
+
+    const [buttonFileChooser] = await Promise.all([
+      managerPage.waitForEvent("filechooser"),
+      managerPage.getByTestId("manager-upload-button").click()
+    ]);
+    await buttonFileChooser.setFiles(workbookPath);
+    await expect(managerPage.getByText("Imported 3 projects.")).toBeVisible();
+    managerPage.once("dialog", (dialog) => void dialog.accept());
+    await managerPage.getByTestId("manager-reset-round").click();
+    await expect(managerPage.getByText("No projects loaded yet")).toBeVisible();
+
+    await anonymousPage.goto("/");
+    await expect(anonymousPage.getByText("No projects loaded yet")).toBeVisible();
+    await takeShot(managerPage, testInfo.outputPath("manager-reset-empty-state.png"));
   });
 
   await Promise.all([

--- a/tests/votes.integration.test.ts
+++ b/tests/votes.integration.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { COMPETITION_STATE_ID, MANAGER_EMAIL } from "@/lib/constants";
 import { prisma } from "@/lib/prisma";
-import { submitJudgeVote } from "@/lib/competition";
+import { resetCompetitionRound, submitJudgeVote } from "@/lib/competition";
 
 async function resetDatabase() {
   await prisma.vote.deleteMany();
@@ -93,5 +93,38 @@ describe("submitJudgeVote", () => {
         score: 9
       })
     ).rejects.toThrow("Team members cannot vote on their own project.");
+  });
+
+  it("resets the round back to an empty preparing state", async () => {
+    const entry = await prisma.entry.create({
+      data: {
+        slug: "harbor-pulse",
+        projectName: "Harbor Pulse",
+        teamEmails: {
+          create: [{ email: "captain@example.com" }]
+        }
+      }
+    });
+
+    await submitJudgeVote({
+      entryId: entry.id,
+      judgeEmail: "judge@example.com",
+      judgeUserId: "user_3",
+      score: 7
+    });
+
+    await resetCompetitionRound();
+
+    expect(await prisma.entry.count()).toBe(0);
+    expect(await prisma.vote.count()).toBe(0);
+    expect(
+      await prisma.competitionState.findUnique({
+        where: { id: COMPETITION_STATE_ID }
+      })
+    ).toMatchObject({
+      votingStatus: "PREPARING",
+      startedAt: null,
+      finalizedAt: null
+    });
   });
 });

--- a/tests/xlsx.test.ts
+++ b/tests/xlsx.test.ts
@@ -2,7 +2,7 @@ import * as XLSX from "xlsx";
 import { describe, expect, it } from "vitest";
 
 import { FINALIZED_RESULTS_SHEET, TEMPLATE_SHEET_NAME } from "@/lib/constants";
-import { buildFinalizedResultsWorkbook, parseEntriesWorkbook } from "@/lib/xlsx";
+import { buildFinalizedResultsWorkbook, buildTemplateWorkbook, parseEntriesWorkbook } from "@/lib/xlsx";
 
 function workbookBuffer(rows: Array<Array<string>>) {
   const workbook = XLSX.utils.book_new();
@@ -85,5 +85,16 @@ describe("buildFinalizedResultsWorkbook", () => {
       "Aggregate Score": 19,
       "Vote Count": 2
     });
+  });
+});
+
+describe("buildTemplateWorkbook", () => {
+  it("creates a blank workbook template without seeded demo projects", () => {
+    const workbook = XLSX.read(buildTemplateWorkbook(), { type: "buffer" });
+    const rows = XLSX.utils.sheet_to_json<Record<string, string>>(workbook.Sheets[TEMPLATE_SHEET_NAME], {
+      defval: ""
+    });
+
+    expect(rows).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- add a manager-only reset flow that returns the app to an empty workbook-driven state
- remove seeded template content and show an intentional empty scoreboard until a workbook is uploaded
- prove the real manager upload gestures with Playwright: upload-card click, drag/drop replacement, and reset plus re-upload

## Why
Managers could get stuck unable to upload a new workbook after a previous rehearsal left the round open or finalized. That made the live app feel broken even though the real problem was missing recovery state. This PR makes the dry-run loop explicit and safe so Rajeev can rehearse the entire event flow by hand.

## What changed
- `POST /api/competition/reset` resets entries, team emails, votes, and lifecycle state back to `PREPARING`
- manager controls now include `Reset dry run`
- the scoreboard and template are intentionally blank until a workbook is uploaded
- anonymous snapshot caching is limited to production so local proof does not serve stale state between test resets
- docs now explain the reset workflow and blank workbook-driven board
- browser proof now covers:
  - clicking the upload surface itself to open the file chooser
  - drag/drop workbook replacement
  - reset, re-upload, and return to empty state

## Validation
- `pnpm check`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`

Closes #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manager can now reset competition rounds to an empty state
  * Template workbook ships completely blank without placeholder projects

* **User Interface**
  * Improved empty-state messaging when no projects are loaded
  * Upload availability messaging now reflects current state dynamically
  * Enhanced manager instructions

* **Documentation**
  * Updated documentation to reflect reset capability and updated workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->