### PR TITLE
gh-8: perfect the voting modal and lock votes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ The app uses a practical judging-round rule:
 - self-vote-blocked projects are removed from that judge's denominator
 - finalization unlocks when every participating judge has scored every project they are eligible to judge
 
+Each judge can submit one score per project. Once submitted, that score is locked for the rest of the round.
+
 More detail lives in [operating-model.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/operating-model.md).
 
 A fuller operational walkthrough lives in [how-it-works.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/how-it-works.md).
@@ -157,12 +159,12 @@ The Playwright suite covers:
 - email-code judge auth
 - modal keyboard voting
 - self-vote blocking
-- single active vote with edits
+- single locked vote per judge per project
 - progress completion
 - finalization
 - public finalized lock state
 - manager XLSX export
-- anonymous cross-device freshness after another judge updates a score
+- anonymous cross-device freshness after another judge casts a score
 
 Cheap event-day readiness checks:
 

--- a/components/results-dashboard.tsx
+++ b/components/results-dashboard.tsx
@@ -480,7 +480,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                 ) : (
                   <>
                     <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4 text-sm leading-7 text-muted-foreground">
-                      Anyone can view the board. Judges sign in once, vote from the modal, and can edit their own score until the manager finalizes the round.
+                      Anyone can view the board. Judges sign in once, cast one score per project from the modal, and that score stays locked unless the manager resets the whole round.
                     </div>
                     <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4 text-sm leading-7 text-muted-foreground">
                       A judge joins the progress denominator the moment they cast their first vote. Completion means every participating judge has scored every entry.

--- a/components/results-scoreboard-table.tsx
+++ b/components/results-scoreboard-table.tsx
@@ -26,7 +26,7 @@ function actionLabel({
   if (status === "PREPARING") return "Opens soon";
   if (entry.isSelfVoteBlocked) return "Team member";
   if (!viewer.isAuthenticated) return "Sign in";
-  return entry.currentUserVote == null ? "Vote" : "Update";
+  return entry.currentUserVote == null ? "Vote" : "Scored";
 }
 
 export function ResultsScoreboardTable({
@@ -115,24 +115,20 @@ export function ResultsScoreboardTable({
                     {entry.totalScore}
                   </motion.div>
                 </div>
-                <Button
-                  className="min-w-[118px] justify-center"
-                  data-testid={`scoreboard-action-${entry.slug}`}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onSelectEntry(entry);
-                  }}
-                  size="sm"
-                  type="button"
-                  variant={status === "OPEN" && !entry.isSelfVoteBlocked ? "default" : "outline"}
-                >
-                  {status !== "OPEN" || entry.isSelfVoteBlocked ? (
-                    <Lock className="h-4 w-4" />
-                  ) : (
-                    <Vote className="h-4 w-4" />
-                  )}
-                  {actionLabel({ entry, status, viewer })}
-                </Button>
+                  <Button
+                    className="min-w-[118px] justify-center"
+                    data-testid={`scoreboard-action-${entry.slug}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onSelectEntry(entry);
+                    }}
+                    size="sm"
+                    type="button"
+                    variant={entry.canVote ? "default" : "outline"}
+                  >
+                    {entry.canVote ? <Vote className="h-4 w-4" /> : <Lock className="h-4 w-4" />}
+                    {actionLabel({ entry, status, viewer })}
+                  </Button>
               </div>
             </motion.div>
           ))}
@@ -212,13 +208,9 @@ export function ResultsScoreboardTable({
                         data-testid={`scoreboard-action-${entry.slug}`}
                         onClick={() => onSelectEntry(entry)}
                         size="sm"
-                        variant={status === "OPEN" && !entry.isSelfVoteBlocked ? "default" : "outline"}
+                        variant={entry.canVote ? "default" : "outline"}
                       >
-                        {status !== "OPEN" || entry.isSelfVoteBlocked ? (
-                          <Lock className="h-4 w-4" />
-                        ) : (
-                          <Vote className="h-4 w-4" />
-                        )}
+                        {entry.canVote ? <Vote className="h-4 w-4" /> : <Lock className="h-4 w-4" />}
                         {actionLabel({ entry, status, viewer })}
                       </Button>
                     </td>

--- a/components/vote-dialog.tsx
+++ b/components/vote-dialog.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { ArrowRight, CheckCircle2, Sparkles } from "lucide-react";
+import {
+  ArrowRight,
+  CheckCircle2,
+  LockKeyhole,
+  Sparkles
+} from "lucide-react";
 import * as React from "react";
 
 import { JudgeAuthPanel } from "@/components/judge-auth-panel";
-import type { ScoreboardEntryView, ViewerIdentity } from "@/lib/competition-logic";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -15,6 +19,7 @@ import {
   DialogTitle
 } from "@/components/ui/dialog";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import type { ScoreboardEntryView, ViewerIdentity } from "@/lib/competition-logic";
 
 type VoteDialogProps = {
   entry: ScoreboardEntryView | null;
@@ -25,6 +30,32 @@ type VoteDialogProps = {
   onVoteSaved: () => void;
 };
 
+const scoreOptions = Array.from({ length: 11 }, (_, value) => value);
+
+function describeScore(score: number) {
+  if (score <= 3) {
+    return {
+      band: "Stretch",
+      summary: "Interesting spark, but still early and unproven.",
+      accentClassName: "bg-radix-gray-a-3 text-muted-foreground"
+    };
+  }
+
+  if (score <= 7) {
+    return {
+      band: "Strong",
+      summary: "Solid execution with clear promise and momentum.",
+      accentClassName: "bg-radix-purple-a-4 text-foreground"
+    };
+  }
+
+  return {
+    band: "Winner",
+    summary: "A standout project you would confidently champion.",
+    accentClassName: "bg-radix-teal-a-4 text-accent-foreground"
+  };
+}
+
 export function VoteDialog({
   entry,
   open,
@@ -33,21 +64,21 @@ export function VoteDialog({
   onOpenChange,
   onVoteSaved
 }: VoteDialogProps) {
-  const [selectedScore, setSelectedScore] = React.useState<string>("");
-  const [message, setMessage] = React.useState<string | null>(null);
+  const [selectedScore, setSelectedScore] = React.useState<string>("7");
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const [state, setState] = React.useState<"idle" | "submitting" | "success" | "error">("idle");
 
   React.useEffect(() => {
     if (!entry || !open) return;
-    setSelectedScore(entry.currentUserVote == null ? "" : String(entry.currentUserVote));
-    setMessage(null);
+    setSelectedScore(entry.currentUserVote == null ? "7" : String(entry.currentUserVote));
+    setErrorMessage(null);
     setState("idle");
   }, [entry?.id, open]);
 
   async function submitVote() {
     if (!entry || !selectedScore) return;
     setState("submitting");
-    setMessage(null);
+    setErrorMessage(null);
 
     try {
       const response = await fetch("/api/votes", {
@@ -67,12 +98,11 @@ export function VoteDialog({
       }
 
       setState("success");
-      setMessage(entry.currentUserVote == null ? "Your score is live on the board." : "Your updated score is live.");
       onVoteSaved();
-      window.setTimeout(() => onOpenChange(false), 1200);
+      window.setTimeout(() => onOpenChange(false), 1500);
     } catch (error) {
       setState("error");
-      setMessage(error instanceof Error ? error.message : "We could not save that vote.");
+      setErrorMessage(error instanceof Error ? error.message : "We could not save that vote.");
     }
   }
 
@@ -81,185 +111,313 @@ export function VoteDialog({
   const isLocked = status !== "OPEN";
   const needsAuth = !viewer.isAuthenticated;
   const isBlocked = entry.isSelfVoteBlocked;
-  const recommendedScore = selectedScore || String(Math.min(10, Math.max(7, entry.currentUserVote ?? 7)));
+  const hasRecordedVote = entry.currentUserVote != null;
+  const previewScore = Number(selectedScore || String(entry.currentUserVote ?? 7));
+  const preview = describeScore(previewScore);
+  const recordedVote = entry.currentUserVote == null ? null : describeScore(entry.currentUserVote);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-hidden p-0">
-        <div className="grid max-h-[85vh] overflow-y-auto md:grid-cols-[1.05fr_0.95fr]">
-          <div className="shell-surface content-grid relative border-b border-border p-6 md:border-b-0 md:border-r md:p-8">
-            <div className="absolute inset-x-0 top-0 h-24 bg-[radial-gradient(circle_at_top_left,var(--hero-glow),transparent_72%)]" />
+      <DialogContent className="w-[min(96vw,70rem)] overflow-hidden border-border/90 p-0">
+        <div className="grid max-h-[94vh] overflow-y-auto lg:grid-cols-[1.08fr_0.92fr]">
+          <div className="shell-surface content-grid relative border-b border-border p-5 md:p-7 lg:border-b-0 lg:border-r lg:p-8">
+            <div className="absolute inset-x-0 top-0 h-28 bg-[radial-gradient(circle_at_top_left,var(--hero-glow),transparent_72%)]" />
             <DialogHeader className="relative">
-              <div className="eyebrow">Judge Vote</div>
-              <DialogTitle>{entry.projectName}</DialogTitle>
-              <DialogDescription className="max-w-md">
+              <div className="eyebrow">Judge vote</div>
+              <DialogTitle className="max-w-2xl text-[clamp(2.15rem,4vw,3.4rem)] leading-[0.95]">
+                {entry.projectName}
+              </DialogTitle>
+              <DialogDescription className="max-w-xl text-[0.95rem] leading-8">
                 {entry.summary ??
-                  "Capture the energy of the project in one clear score from 0 to 10. Judges can revise their score until the manager finalizes the round."}
+                  "Capture the energy of the project in one clear score from 0 to 10. Judges get one shot per project, so the interaction should feel decisive and obvious."}
               </DialogDescription>
             </DialogHeader>
 
-            <div className="relative mt-8 space-y-5">
-              <div className="glass-panel rounded-[1.75rem] p-5">
-                <div className="flex flex-wrap gap-2">
+            <div className="relative mt-6 space-y-4">
+              <div className="glass-panel rounded-[1.9rem] p-5">
+                <div className="flex flex-wrap items-center gap-2">
                   {entry.teamName ? (
                     <span className="rounded-full bg-radix-gray-a-3 px-3 py-1 text-xs font-semibold text-muted-foreground">
                       {entry.teamName}
                     </span>
                   ) : null}
+                  <span className="rounded-full bg-radix-teal-a-3 px-3 py-1 text-xs font-semibold text-accent-foreground">
+                    {entry.voteCount} submitted vote{entry.voteCount === 1 ? "" : "s"}
+                  </span>
                 </div>
-                <div className="mt-5 flex items-end gap-3">
-                  <div className="font-display text-5xl font-black text-primary" data-testid="vote-dialog-aggregate-total">
-                    {entry.totalScore}
+
+                <div className="mt-6 grid gap-4 sm:grid-cols-[0.95fr_1.05fr]">
+                  <div className="rounded-[1.6rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-5">
+                    <div className="eyebrow">Live aggregate</div>
+                    <div
+                      className="mt-3 font-display text-6xl font-black text-primary"
+                      data-testid="vote-dialog-aggregate-total"
+                    >
+                      {entry.totalScore}
+                    </div>
+                    <div
+                      className="mt-3 text-sm font-medium text-muted-foreground"
+                      data-testid="vote-dialog-aggregate-summary"
+                    >
+                      {entry.averageScore == null
+                        ? "No average yet"
+                        : `${entry.averageScore} average across ${entry.voteCount} vote${entry.voteCount === 1 ? "" : "s"}`}
+                    </div>
                   </div>
-                  <div
-                    className="pb-2 text-sm font-medium text-muted-foreground"
-                    data-testid="vote-dialog-aggregate-summary"
-                  >
-                    aggregate points
-                    <div>{entry.voteCount} submitted vote{entry.voteCount === 1 ? "" : "s"}</div>
+
+                  <div className="rounded-[1.6rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-5">
+                    <div className="eyebrow">Judging stance</div>
+                    <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em]">
+                      <span className="rounded-full bg-radix-gray-a-3 px-3 py-2 text-muted-foreground">
+                        0-3 Stretch
+                      </span>
+                      <span className="rounded-full bg-radix-purple-a-4 px-3 py-2 text-foreground">
+                        4-7 Strong
+                      </span>
+                      <span className="rounded-full bg-radix-teal-a-4 px-3 py-2 text-accent-foreground">
+                        8-10 Winner
+                      </span>
+                    </div>
+                    <p className="mt-4 text-sm leading-7 text-muted-foreground">
+                      Choose the number that best captures your conviction. Once you submit, that vote locks immediately for the rest of the round.
+                    </p>
                   </div>
                 </div>
-                <p className="mt-4 text-sm leading-7 text-muted-foreground">
-                  Tap a score and submit. The public scoreboard updates right away with smooth rank changes.
-                </p>
               </div>
 
+              {hasRecordedVote ? (
+                <div className="rounded-[1.7rem] border border-radix-teal-a-6 bg-radix-teal-a-3 p-5 text-accent-foreground">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <CheckCircle2 className="h-5 w-5" />
+                    <span className="text-sm font-semibold uppercase tracking-[0.2em]">Recorded score</span>
+                  </div>
+                  <div className="mt-4 flex flex-wrap items-end gap-4">
+                    <div className="font-display text-5xl font-black">{entry.currentUserVote}</div>
+                    <div className="pb-2 text-sm font-medium">
+                      <div>{recordedVote?.band}</div>
+                      <div>{recordedVote?.summary}</div>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
               {isBlocked ? (
-                <div className="rounded-[1.5rem] border border-[rgb(217_140_20_/_0.28)] bg-[rgb(217_140_20_/_0.08)] p-5 text-sm leading-7 text-foreground">
+                <div className="rounded-[1.6rem] border border-[rgb(217_140_20_/_0.28)] bg-[rgb(217_140_20_/_0.08)] p-5 text-sm leading-7 text-foreground">
                   Self-voting is blocked automatically because your signed-in email matches a submitted team email for this project.
                 </div>
               ) : null}
 
-              {message ? (
+              {errorMessage ? (
                 <div
                   aria-live="polite"
-                  className={`rounded-[1.5rem] border p-4 text-sm ${
-                    state === "error"
-                      ? "border-[rgb(204_63_79_/_0.25)] bg-[rgb(204_63_79_/_0.08)] text-foreground"
-                      : "border-radix-teal-a-6 bg-radix-teal-a-3 text-accent-foreground"
-                  }`}
+                  className="rounded-[1.6rem] border border-[rgb(204_63_79_/_0.25)] bg-[rgb(204_63_79_/_0.08)] p-4 text-sm text-foreground"
                 >
-                  {message}
+                  {errorMessage}
                 </div>
               ) : null}
             </div>
           </div>
 
-          <div className="relative p-6 md:p-8">
+          <div className="relative p-5 md:p-7 lg:p-8">
             <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,var(--hero-glow),transparent_55%)]" />
             <div className="relative flex h-full flex-col">
               <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-muted-foreground">
                 <Sparkles className="h-4 w-4 text-primary" />
-                <span>Choose one score from 0 to 10.</span>
+                <span>The score pad is fully keyboard friendly and optimized for quick judging.</span>
               </div>
 
               {isLocked ? (
-                <div className="glass-panel flex flex-1 flex-col justify-center rounded-[1.75rem] p-6">
-                  <h3 className="font-display text-2xl font-black">
+                <div className="glass-panel flex flex-1 flex-col justify-center rounded-[1.9rem] p-6 sm:p-7">
+                  <h3 className="font-display text-3xl font-black">
                     {status === "PREPARING" ? "Voting opens soon" : "Judging is finalized"}
                   </h3>
-                  <p className="mt-3 text-sm leading-7 text-muted-foreground">
+                  <p className="mt-4 max-w-md text-sm leading-7 text-muted-foreground">
                     {status === "PREPARING"
-                      ? "The scoreboard is live, but the manager has not opened the round yet."
-                      : "Finalized results are now locked. Thanks for judging."}
+                      ? "The board is visible already, but the manager has not opened the round yet."
+                      : "Finalized results are locked now. Thanks for helping judge the field."}
                   </p>
                 </div>
               ) : needsAuth ? (
-                <div className="glass-panel flex flex-1 flex-col justify-between rounded-[1.75rem] p-6">
+                <div className="glass-panel flex flex-1 flex-col justify-between rounded-[1.9rem] p-6 sm:p-7">
                   <JudgeAuthPanel
                     afterAuthenticate={() => {
-                      setMessage("You're signed in. Pick a score and send it.");
                       onVoteSaved();
                     }}
-                    description="The board stays public, but signing in unlocks one forgiving score per project, with edits allowed until the manager finalizes the round."
-                    title="Sign in and score this project"
+                    description="The board stays public, but signing in unlocks a single decisive score per project. Once you submit, that score is locked for the round."
+                    title="Sign in to cast your vote"
                   />
                 </div>
               ) : isBlocked ? (
-                <div className="glass-panel flex flex-1 flex-col justify-center rounded-[1.75rem] p-6">
-                  <h3 className="font-display text-2xl font-black">You can’t score this one</h3>
-                  <p className="mt-3 text-sm leading-7 text-muted-foreground">
-                    We block self-voting automatically to keep judging fair and friction-free for the manager.
+                <div className="glass-panel flex flex-1 flex-col justify-center rounded-[1.9rem] p-6 sm:p-7">
+                  <h3 className="font-display text-3xl font-black">You can’t score this one</h3>
+                  <p className="mt-4 max-w-md text-sm leading-7 text-muted-foreground">
+                    We block self-voting automatically so judges never need to second-guess whether a score is allowed.
                   </p>
                 </div>
-              ) : (
-                <div className="glass-panel flex flex-1 flex-col rounded-[1.75rem] p-5">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="eyebrow">Your score</div>
-                      <h3 className="mt-2 font-display text-2xl font-black">
-                        {entry.currentUserVote == null ? "Make it count" : "Adjust your call"}
-                      </h3>
+              ) : hasRecordedVote ? (
+                <div className="glass-panel flex flex-1 flex-col justify-between rounded-[1.9rem] p-6 sm:p-7">
+                  <div>
+                    <div className="eyebrow">Vote locked</div>
+                    <h3 className="mt-2 font-display text-3xl font-black">Score recorded</h3>
+                    <p className="mt-4 max-w-md text-sm leading-7 text-muted-foreground">
+                      Each judge gets one vote per project in this round. Your score is already on the board and cannot be changed now.
+                    </p>
+                  </div>
+
+                  <div className="mt-6 rounded-[1.7rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-5">
+                    <div className="flex items-center gap-3">
+                      <LockKeyhole className="h-5 w-5 text-primary" />
+                      <span className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                        Your submitted score
+                      </span>
                     </div>
-                    <div className="rounded-full bg-radix-gray-a-3 px-3 py-1 text-xs font-semibold text-muted-foreground">
-                      {entry.currentUserVote == null ? "New score" : `Current: ${entry.currentUserVote}`}
+                    <div className="mt-4 flex items-end gap-4">
+                      <div className="font-display text-6xl font-black text-foreground">{entry.currentUserVote}</div>
+                      <div className="pb-2 text-sm text-muted-foreground">
+                        <div className="font-semibold text-foreground">{recordedVote?.band}</div>
+                        <div>{recordedVote?.summary}</div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="glass-panel flex flex-1 flex-col rounded-[1.9rem] p-5">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <div className="eyebrow">Cast your only vote</div>
+                      <h3 className="mt-2 font-display text-3xl font-black">Make it count</h3>
+                    </div>
+                    <div className="inline-flex items-center rounded-full bg-radix-gray-a-3 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      No edits after submit
+                    </div>
+                  </div>
+
+                  <div className="mt-5 rounded-[1.6rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-4">
+                      <div>
+                        <div className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                          Selected score
+                        </div>
+                        <div className="mt-3 flex items-end gap-4">
+                          <div className="font-display text-6xl font-black text-primary">{previewScore}</div>
+                          <div className="pb-2">
+                            <div className="text-lg font-semibold text-foreground">{preview.band}</div>
+                            <div className="max-w-xs text-sm leading-7 text-muted-foreground">
+                              {preview.summary}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className={`rounded-full px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] ${preview.accentClassName}`}
+                      >
+                        {preview.band}
+                      </div>
                     </div>
                   </div>
 
                   <RadioGroup
-                    className="mt-6 grid grid-cols-3 gap-3 sm:grid-cols-4"
+                    className="mt-5 grid grid-cols-4 gap-2.5 sm:grid-cols-4 lg:grid-cols-4"
                     value={selectedScore}
                     onValueChange={setSelectedScore}
                   >
-                    {Array.from({ length: 11 }, (_, value) => value).map((value) => (
-                      <RadioGroupItem
-                        aria-label={`Score ${value}`}
-                        autoFocus={String(value) === recommendedScore}
-                        key={value}
-                        value={String(value)}
-                        className="group flex h-20 flex-col items-center justify-center"
-                        data-testid={`score-option-${value}`}
-                      >
-                        <span className="font-display text-3xl font-black">{value}</span>
-                        <span className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground group-data-[state=checked]:text-accent-foreground">
-                          {value <= 3 ? "Stretch" : value <= 7 ? "Strong" : "Winner"}
-                        </span>
-                      </RadioGroupItem>
-                    ))}
+                    {scoreOptions.map((value) => {
+                      const tone = describeScore(value);
+
+                      return (
+                        <RadioGroupItem
+                          aria-label={`Score ${value}, ${tone.band}`}
+                          autoFocus={value === 7}
+                          key={value}
+                          value={String(value)}
+                          className="group relative flex aspect-[0.98] min-h-[72px] flex-col items-start justify-between overflow-hidden rounded-[1.55rem] border-border/80 bg-[rgb(255_255_255_/_0.03)] p-3.5 text-left hover:-translate-y-0.5 data-[state=checked]:shadow-[0_18px_50px_var(--shadow-soft)] sm:min-h-[84px]"
+                          data-testid={`score-option-${value}`}
+                        >
+                          <span className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-transparent via-radix-teal-a-6 to-transparent opacity-0 transition group-data-[state=checked]:opacity-100" />
+                          <span className="font-display text-[2rem] font-black leading-none sm:text-[2.15rem]">{value}</span>
+                          <span className="text-[0.62rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground group-data-[state=checked]:text-accent-foreground">
+                            {tone.band}
+                          </span>
+                        </RadioGroupItem>
+                      );
+                    })}
                   </RadioGroup>
 
-                  <p className="mt-5 text-sm leading-7 text-muted-foreground">
-                    Keyboard friendly: tab into the score grid, then use arrow keys to move across values and press space or enter to choose.
+                  <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                    Tab into the score grid, then use arrow keys and press space or enter to choose.
                   </p>
 
-                  <div className="mt-auto pt-6">
-                    <Button
-                      className="w-full justify-center"
-                      data-testid="submit-vote"
-                      disabled={!selectedScore || state === "submitting"}
-                      onClick={submitVote}
-                      size="lg"
-                    >
-                      {state === "submitting"
-                        ? "Saving score..."
-                        : entry.currentUserVote == null
-                          ? "Submit score"
-                          : "Update score"}
-                    </Button>
+                  <div className="mt-auto pt-5">
+                    <AnimatePresence mode="wait">
+                      {state === "success" ? (
+                        <motion.div
+                          key="vote-success"
+                          animate={{ opacity: 1, y: 0 }}
+                          aria-live="polite"
+                          className="rounded-[1.7rem] border border-radix-teal-a-6 bg-radix-teal-a-3 p-4 text-accent-foreground shadow-halo"
+                          data-testid="vote-saved-toast"
+                          exit={{ opacity: 0, y: 10 }}
+                          initial={{ opacity: 0, y: 14 }}
+                          role="status"
+                        >
+                          <div className="flex items-start gap-3">
+                            <div className="mt-1 rounded-full bg-[rgb(255_255_255_/_0.14)] p-2">
+                              <CheckCircle2 className="h-5 w-5" />
+                            </div>
+                            <div>
+                              <div className="text-sm font-semibold uppercase tracking-[0.18em]">
+                                Vote locked in
+                              </div>
+                              <div className="mt-2 font-display text-2xl font-black">
+                                {previewScore} points recorded
+                              </div>
+                              <div className="mt-2 text-sm leading-7">
+                                Your score is live on the board now. This project is locked for the rest of the round.
+                              </div>
+                            </div>
+                          </div>
+                        </motion.div>
+                      ) : (
+                        <motion.div
+                          key="vote-cta"
+                          animate={{ opacity: 1, y: 0 }}
+                          className="rounded-[1.7rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4"
+                          exit={{ opacity: 0, y: 10 }}
+                          initial={{ opacity: 0, y: 14 }}
+                        >
+                          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                            <div className="min-w-0">
+                              <div className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                                Ready to submit
+                              </div>
+                              <div className="mt-2 text-sm leading-7 text-muted-foreground">
+                                You are about to lock{" "}
+                                <span className="font-semibold text-foreground">{previewScore}</span> for this project.
+                              </div>
+                            </div>
+                            <Button
+                              className="min-w-[220px] justify-center"
+                              data-testid="submit-vote"
+                              disabled={!selectedScore || state === "submitting"}
+                              onClick={submitVote}
+                              size="lg"
+                            >
+                              {state === "submitting" ? (
+                                "Locking vote..."
+                              ) : (
+                                <>
+                                  Lock score
+                                  <ArrowRight className="h-4 w-4" />
+                                </>
+                              )}
+                            </Button>
+                          </div>
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
                   </div>
                 </div>
               )}
-
-              <AnimatePresence>
-                {state === "success" ? (
-                  <motion.div
-                    initial={{ opacity: 0, y: 12 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: 8 }}
-                    aria-live="polite"
-                    className="pointer-events-none absolute inset-0 flex items-end justify-center p-6"
-                  >
-                    <div
-                      className="rounded-full border border-radix-teal-a-6 bg-radix-teal-a-4 px-5 py-3 text-sm font-semibold text-accent-foreground shadow-halo"
-                      data-testid="vote-saved-toast"
-                      role="status"
-                    >
-                      <CheckCircle2 className="mr-2 inline h-4 w-4" />
-                      Vote saved
-                    </div>
-                  </motion.div>
-                ) : null}
-              </AnimatePresence>
             </div>
           </div>
         </div>

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -33,7 +33,7 @@ The app is intentionally a single-screen product.
 - Any authenticated non-manager user is treated as a judge.
 - Judges can sign in with Google or email code.
 - Judges can score a project from `0` to `10`.
-- Judges can edit their own score until the round is finalized.
+- Judges get one score per project. Once submitted, that score is locked for the rest of the round.
 
 ## Auth
 
@@ -130,7 +130,7 @@ The production data model is intentionally small.
 - `CompetitionState`: manager identity, lifecycle state, started/finalized timestamps
 - `Entry`: uploaded project row and aggregate project metadata
 - `EntryTeamEmail`: normalized team emails used for self-vote blocking
-- `Vote`: one active judge score per project, editable until finalization
+- `Vote`: one locked judge score per project for the active round
 
 See [/Users/rajeev/Code/hackathon-voting-prototype/prisma/schema.prisma](/Users/rajeev/Code/hackathon-voting-prototype/prisma/schema.prisma) for the exact schema and [/Users/rajeev/Code/hackathon-voting-prototype/docs/operating-model.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/operating-model.md) for the rule details.
 

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -24,7 +24,8 @@ The app is intentionally a single-screen hackathon voting surface.
 - The preferred auth path is Google SSO when enabled in Clerk.
 - The required fallback path is email code auth, which is fully wired and covered by proof.
 - Judges can cast one active score per project from `0` to `10`.
-- Judges can revise their own score until finalization.
+- Judges can submit exactly one score per project.
+- Once submitted, that score is locked for the rest of the round.
 
 ### Manager
 
@@ -112,7 +113,8 @@ Self-vote blocking is derived from normalized email equality between the signed-
 - Public scoreboard stays visible.
 - Authenticated judges can vote.
 - A judge becomes part of the progress denominator the moment they cast their first score.
-- A judge can edit their score for the same project; the vote row is updated in place.
+- Each judge can submit exactly one score per project for the active round.
+- After submission, that project is locked for that judge unless the manager resets the whole round.
 - Active scoreboard tabs auto-refresh every 5 seconds during judging, and focused tabs also refresh on visibility or focus return.
 
 ### `FINALIZED`

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -25,10 +25,11 @@ Flows proven:
 - Anonymous user can view the scoreboard but not manager controls
 - Manager downloads the XLSX template
 - Manager uploads a workbook and seeded entries appear
+- Manager uploads a workbook and workbook-driven entries appear
 - Manager begins voting
 - Judge signs in with email-code auth
 - Vote modal supports keyboard selection and submission
-- Judge edits an existing vote without creating a duplicate active vote
+- Judge is locked out from changing a project after submitting the first vote
 - Self-voting is blocked for matching team emails
 - Progress reaches completion under the documented denominator rule
 - Manager finalizes the round
@@ -93,7 +94,7 @@ Behavior proof:
 
 - Public scoreboard is reachable without auth
 - Manager template download, workbook upload, begin-voting, finalization, and export all complete successfully
-- The vote modal opens from the scoreboard, accepts keyboard score selection, submits successfully, and supports score edits
+- The vote modal opens from the scoreboard, accepts keyboard score selection, submits successfully, and then locks the judge out from changing that project
 - Self-vote blocking is enforced from uploaded team emails
 - Finalized public state locks the modal and keeps the scoreboard readable
 

--- a/lib/competition-logic.ts
+++ b/lib/competition-logic.ts
@@ -235,6 +235,7 @@ export function deriveCompetitionSnapshot({
         status === "OPEN" &&
         viewer.isAuthenticated &&
         !entry.isSelfVoteBlocked &&
+        entry.currentUserVote == null &&
         Boolean(viewer.email)
     }));
 

--- a/lib/competition.ts
+++ b/lib/competition.ts
@@ -277,26 +277,27 @@ export async function submitJudgeVote({
     throw new Error("Team members cannot vote on their own project.");
   }
 
-  await withPrismaRetry(() =>
-    prisma.vote.upsert({
-      where: {
-        entryId_judgeEmail: {
+  try {
+    await withPrismaRetry(() =>
+      prisma.vote.create({
+        data: {
           entryId,
-          judgeEmail: normalizedJudgeEmail
+          judgeEmail: normalizedJudgeEmail,
+          judgeUserId,
+          score
         }
-      },
-      update: {
-        score,
-        judgeUserId
-      },
-      create: {
-        entryId,
-        judgeEmail: normalizedJudgeEmail,
-        judgeUserId,
-        score
-      }
-    })
-  );
+      })
+    );
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      throw new Error("You've already scored this project. Votes lock after submission.");
+    }
+
+    throw error;
+  }
 
   safeRevalidateHome();
 }

--- a/tests/competition-logic.test.ts
+++ b/tests/competition-logic.test.ts
@@ -47,6 +47,7 @@ describe("competition logic", () => {
     expect(snapshot.canFinalize).toBe(true);
     expect(snapshot.entries.find((entry) => entry.id === "entry-2")?.isSelfVoteBlocked).toBe(true);
     expect(snapshot.entries.find((entry) => entry.id === "entry-1")?.currentUserVote).toBe(9);
+    expect(snapshot.entries.find((entry) => entry.id === "entry-1")?.canVote).toBe(false);
   });
 
   it("does not mark the round complete when an eligible project is still missing a score", () => {

--- a/tests/e2e/single-screen-voting.spec.ts
+++ b/tests/e2e/single-screen-voting.spec.ts
@@ -260,7 +260,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
   await test.step("Anonymous users stay read-only after voting opens", async () => {
     await anonymousPage.goto("/");
     await openVoteDialog(anonymousPage, "Aurora Atlas");
-    await expect(anonymousPage.getByText("Sign in and score this project")).toBeVisible();
+    await expect(anonymousPage.getByText("Sign in to cast your vote")).toBeVisible();
     await expect(anonymousPage.getByTestId("submit-vote")).toHaveCount(0);
     await anonymousPage.getByRole("button", { name: "Close" }).click();
   });
@@ -276,6 +276,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await expect(voteDialog.getByTestId("score-option-7")).toBeFocused();
     await judgePage.keyboard.press("Space");
     await expect(voteDialog.getByTestId("score-option-7")).toHaveAttribute("data-state", "checked");
+    await takeShot(judgePage, testInfo.outputPath("judge-modal-before-submit.png"));
     await judgePage.keyboard.press("Tab");
     await expect(voteDialog.getByTestId("submit-vote")).toBeFocused();
     await judgePage.keyboard.press("Enter");
@@ -285,7 +286,13 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await saveVote(judgePage, 7);
 
     await openVoteDialog(judgePage, "Signal Bloom");
-    await saveVote(judgePage, 9);
+    await expect(judgePage.getByRole("heading", { name: "Score recorded" })).toBeVisible();
+    await expect(
+      judgePage.getByText("Each judge gets one vote per project in this round.")
+    ).toBeVisible();
+    await expect(judgePage.getByTestId("submit-vote")).toHaveCount(0);
+    await takeShot(judgePage, testInfo.outputPath("judge-modal-locked-after-vote.png"));
+    await judgePage.getByRole("button", { name: "Close" }).click();
 
     const signalBloomRow = judgePage.getByTestId("scoreboard-row-signal-bloom").nth(
       activeResponsiveIndex(testInfo.project.name)
@@ -294,13 +301,13 @@ test("manager, judges, and public users complete the single-screen voting flow",
       activeResponsiveIndex(testInfo.project.name)
     );
     await expect(signalBloomRow).toContainText("1 vote");
-    await expect(signalBloomRow).toContainText("9");
-    await expect(signalBloomAction).toContainText("Update");
+    await expect(signalBloomRow).toContainText("7");
+    await expect(signalBloomAction).toContainText("Scored");
     await expect(
       anonymousPage
         .getByTestId("scoreboard-row-signal-bloom")
         .nth(activeResponsiveIndex(testInfo.project.name))
-    ).toContainText("9", { timeout: 12000 });
+    ).toContainText("7", { timeout: 12000 });
 
     await openVoteDialog(judgePage, "Harbor Pulse");
     await saveVote(judgePage, 6);
@@ -358,7 +365,9 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await expect(anonymousPage.getByText("Finalized", { exact: true })).toBeVisible();
     await openVoteDialog(anonymousPage, "Signal Bloom");
     await expect(anonymousPage.getByRole("heading", { name: "Judging is finalized" })).toBeVisible();
-    await expect(anonymousPage.getByText("Finalized results are now locked. Thanks for judging.")).toBeVisible();
+    await expect(
+      anonymousPage.getByText("Finalized results are locked now. Thanks for helping judge the field.")
+    ).toBeVisible();
 
     const hasHorizontalOverflow = await anonymousPage.evaluate(
       () => document.documentElement.scrollWidth > window.innerWidth + 1

--- a/tests/votes.integration.test.ts
+++ b/tests/votes.integration.test.ts
@@ -41,7 +41,7 @@ describe("submitJudgeVote", () => {
     await resetDatabase();
   });
 
-  it("upserts a judge vote instead of creating duplicates", async () => {
+  it("stores the first judge vote and blocks later attempts to change it", async () => {
     const entry = await prisma.entry.create({
       data: {
         slug: "aurora-atlas",
@@ -59,19 +59,21 @@ describe("submitJudgeVote", () => {
       score: 6
     });
 
-    await submitJudgeVote({
-      entryId: entry.id,
-      judgeEmail: "judge@example.com",
-      judgeUserId: "user_1",
-      score: 8
-    });
+    await expect(
+      submitJudgeVote({
+        entryId: entry.id,
+        judgeEmail: "judge@example.com",
+        judgeUserId: "user_1",
+        score: 8
+      })
+    ).rejects.toThrow("You've already scored this project. Votes lock after submission.");
 
     const votes = await prisma.vote.findMany({
       where: { entryId: entry.id }
     });
 
     expect(votes).toHaveLength(1);
-    expect(votes[0]?.score).toBe(8);
+    expect(votes[0]?.score).toBe(6);
   });
 
   it("blocks self-voting when the judge email matches an uploaded team email", async () => {


### PR DESCRIPTION
## Summary
- rebuild the voting modal into a more deliberate, premium judging surface
- remove score-update behavior so each judge gets one locked vote per project
- extend proof to cover the new locked-after-submit modal state on desktop and mobile

## Why
The voting modal is the core interaction in the app. It still had overlapping score labels, a cramped CTA area, and a forgiving update flow that no longer matched the product direction. This PR makes the modal feel like the center of the experience and removes the ambiguity around repeat voting.

## What changed
- redesigned `components/vote-dialog.tsx` with:
  - stronger project context and aggregate framing
  - non-overlapping score cards
  - a cleaner selected-score preview
  - a composed submission area with success state that no longer collides with the CTA
  - a dedicated locked-after-submit state for judges who already voted
- changed vote submission in `lib/competition.ts` from upsert to create-only, with a clear duplicate-vote error
- changed snapshot and scoreboard behavior so voted entries show `Scored` instead of `Update`
- updated docs and tests to reflect the new one-vote-only rule

## Validation
- `pnpm check`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`

Closes #8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Judge votes now lock after submission per project for the active round and cannot be edited

* **Updates**
  * Vote action buttons changed from "Update" to "Scored" after casting
  * Modal displays confirmation when vote is locked in
  * Documentation updated to reflect voting behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->