### PR TITLE
gh-10: persist mobile email-code verification state

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Proof notes live in [proof.md](/Users/rajeev/Code/hackathon-voting-prototype/doc
 - Production uses Clerk live keys on `vote.rajeevg.com`; development continues to use test keys locally.
 - Google OAuth is configured for the production Clerk instance and production app domain.
 - The live verification email already arrives branded from `Hackathon Voting App <notifications@vote.rajeevg.com>`.
+- If a mobile judge switches to their email app to fetch the one-time code and then returns, the app restores the pending verification step instead of dropping them back on the email-entry form.
 - Production verification-email template editing is still limited by the current Clerk plan; deeper subject/body customization requires a Clerk plan upgrade or a custom email-delivery integration.
 
 ## Production URL

--- a/components/judge-auth-panel.tsx
+++ b/components/judge-auth-panel.tsx
@@ -21,6 +21,16 @@ type Notice = {
   text: string;
 };
 
+type PersistedJudgeAuthState = {
+  step: "identify" | "verify";
+  flow: "sign-in" | "sign-up";
+  email: string;
+  emailAddressId: string | null;
+  safeIdentifier: string | null;
+};
+
+export const judgeAuthStorageKey = "hackathon-voting:judge-auth";
+
 function getErrorMessage(error: unknown) {
   if (isClerkAPIResponseError(error) && error.errors[0]?.longMessage) {
     return error.errors[0].longMessage;
@@ -59,23 +69,94 @@ function createGeneratedPassword() {
   return `Judge-${crypto.randomUUID()}-Aa1`;
 }
 
+export function readPersistedJudgeAuthState(): PersistedJudgeAuthState | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = window.sessionStorage.getItem(judgeAuthStorageKey);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<PersistedJudgeAuthState>;
+    if (
+      (parsed.step === "identify" || parsed.step === "verify") &&
+      (parsed.flow === "sign-in" || parsed.flow === "sign-up") &&
+      typeof parsed.email === "string"
+    ) {
+      return {
+        step: parsed.step,
+        flow: parsed.flow,
+        email: parsed.email,
+        emailAddressId: typeof parsed.emailAddressId === "string" ? parsed.emailAddressId : null,
+        safeIdentifier: typeof parsed.safeIdentifier === "string" ? parsed.safeIdentifier : null
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export function hasPendingJudgeAuthVerification() {
+  return readPersistedJudgeAuthState()?.step === "verify";
+}
+
+function clearPersistedJudgeAuthState() {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.removeItem(judgeAuthStorageKey);
+}
+
 export function JudgeAuthPanel({
   title = "Sign in to judge",
   description = "Use Google if it's available on this Clerk instance, or request a one-time email code to keep judging simple on the day.",
   afterAuthenticate,
   className
 }: JudgeAuthPanelProps) {
+  const persistedState = React.useMemo(() => readPersistedJudgeAuthState(), []);
   const router = useRouter();
   const { isLoaded, signIn, setActive } = useSignIn();
   const { signUp } = useSignUp();
-  const [step, setStep] = React.useState<"identify" | "verify">("identify");
-  const [flow, setFlow] = React.useState<"sign-in" | "sign-up">("sign-in");
-  const [email, setEmail] = React.useState("");
+  const [step, setStep] = React.useState<"identify" | "verify">(persistedState?.step ?? "identify");
+  const [flow, setFlow] = React.useState<"sign-in" | "sign-up">(persistedState?.flow ?? "sign-in");
+  const [email, setEmail] = React.useState(persistedState?.email ?? "");
   const [code, setCode] = React.useState("");
   const [notice, setNotice] = React.useState<Notice | null>(null);
   const [pending, setPending] = React.useState<"idle" | "email" | "verify" | "google">("idle");
-  const [emailAddressId, setEmailAddressId] = React.useState<string | null>(null);
-  const [safeIdentifier, setSafeIdentifier] = React.useState<string | null>(null);
+  const [emailAddressId, setEmailAddressId] = React.useState<string | null>(
+    persistedState?.emailAddressId ?? null
+  );
+  const [safeIdentifier, setSafeIdentifier] = React.useState<string | null>(
+    persistedState?.safeIdentifier ?? null
+  );
+
+  React.useEffect(() => {
+    if (step !== "verify") return;
+    if (notice) return;
+
+    setNotice({
+      tone: "info",
+      text: `Enter the latest 6-digit code we emailed to ${safeIdentifier ?? email}.`
+    });
+  }, [email, notice, safeIdentifier, step]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    if (step === "identify" && !email.trim()) {
+      clearPersistedJudgeAuthState();
+      return;
+    }
+
+    const stateToPersist: PersistedJudgeAuthState = {
+      step,
+      flow,
+      email,
+      emailAddressId,
+      safeIdentifier
+    };
+
+    window.sessionStorage.setItem(judgeAuthStorageKey, JSON.stringify(stateToPersist));
+  }, [email, emailAddressId, flow, safeIdentifier, step]);
 
   async function requestEmailCode() {
     if (!isLoaded || !signIn || !signUp) return;
@@ -187,6 +268,7 @@ export function JudgeAuthPanel({
         await setActive({
           session: attempt.createdSessionId
         });
+        clearPersistedJudgeAuthState();
 
         setNotice({
           tone: "success",
@@ -205,6 +287,7 @@ export function JudgeAuthPanel({
         await setActive({
           session: attempt.createdSessionId
         });
+        clearPersistedJudgeAuthState();
 
         setNotice({
           tone: "success",
@@ -282,8 +365,10 @@ export function JudgeAuthPanel({
   }
 
   function startOver() {
+    clearPersistedJudgeAuthState();
     setFlow("sign-in");
     setStep("identify");
+    setEmail("");
     setCode("");
     setEmailAddressId(null);
     setSafeIdentifier(null);

--- a/components/results-dashboard.tsx
+++ b/components/results-dashboard.tsx
@@ -17,6 +17,7 @@ import {
 
 import type { CompetitionSnapshot, ScoreboardEntryView } from "@/lib/competition-logic";
 import { JudgeAuthDialog } from "@/components/judge-auth-dialog";
+import { hasPendingJudgeAuthVerification } from "@/components/judge-auth-panel";
 import { ResultsScoreboardTable } from "@/components/results-scoreboard-table";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { VoteDialog } from "@/components/vote-dialog";
@@ -73,6 +74,12 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
     authDialogOpen ||
     uploadState.status === "uploading" ||
     pendingAction;
+
+  React.useEffect(() => {
+    if (snapshot.viewer.isAuthenticated) return;
+    if (!hasPendingJudgeAuthVerification()) return;
+    setAuthDialogOpen(true);
+  }, [snapshot.viewer.isAuthenticated]);
 
   function refreshBoard() {
     startTransition(() => {

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -43,6 +43,7 @@ Auth is handled by Clerk.
 - Production Clerk frontend API domain: `clerk.vote.rajeevg.com`
 - Google OAuth is enabled on production.
 - Email-code auth is enabled as the fallback and works on production.
+- If a judge requests an email code on mobile, switches to their email app, and returns, the app restores the pending verification step so they can enter the code immediately instead of restarting from the email form.
 
 Live email behavior on production:
 

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -2,7 +2,7 @@
 
 ## Local proof
 
-Date: `2026-03-23`
+Date: `2026-03-24`
 
 Surface: local production build via `next start`
 
@@ -24,10 +24,10 @@ Flows proven:
 
 - Anonymous user can view the scoreboard but not manager controls
 - Manager downloads the XLSX template
-- Manager uploads a workbook and seeded entries appear
 - Manager uploads a workbook and workbook-driven entries appear
 - Manager begins voting
 - Judge signs in with email-code auth
+- The mobile email-code auth flow survives a page remount and returns to the verification step instead of resetting to email entry
 - Vote modal supports keyboard selection and submission
 - Judge is locked out from changing a project after submitting the first vote
 - Self-voting is blocked for matching team emails

--- a/tests/e2e/single-screen-voting.spec.ts
+++ b/tests/e2e/single-screen-voting.spec.ts
@@ -162,6 +162,10 @@ async function signInJudgeWithEmailCode(page: Page, email: string) {
   await page.getByRole("textbox", { name: "Email address" }).fill(email);
   await page.getByTestId("send-email-code").click();
   await expect(page.getByRole("textbox", { name: "Verification code" })).toBeVisible();
+  await expect(page.getByText(`Checking in as ${email}`)).toBeVisible();
+  await page.reload();
+  await expect(page.getByRole("textbox", { name: "Verification code" })).toBeVisible();
+  await expect(page.getByText(`Checking in as ${email}`)).toBeVisible();
   await page.getByRole("textbox", { name: "Verification code" }).fill("424242");
   await page.getByTestId("verify-email-code").click();
   await expect(page.getByText("Judge", { exact: true })).toBeVisible();


### PR DESCRIPTION
## Summary
- persist pending judge email-code verification state in session storage
- automatically reopen the judge auth dialog when a pending verification step exists
- prove the mobile remount path in Playwright and document the behavior

## Tickets
- Closes #10

## Validation
- pnpm check
- pnpm test
- pnpm build
- pnpm test:e2e --project=mobile-dark
- pnpm test:e2e

## Acceptance notes
- a mobile judge can request an email code, leave the app, return, and continue from the verification step instead of restarting from the email form
- the wider single-screen manager/judge/public flow still passes on desktop and mobile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Judge authentication session now persists when you return to the app
  * Authentication dialog automatically opens when a pending verification is detected

* **Bug Fixes**
  * Mobile email-code verification flow now correctly resumes at the verification step instead of restarting from the email-entry form when you return from your email app

* **Documentation**
  * Updated documentation describing improved mobile email-code verification behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->