### PR TITLE
gh-14: fix progress card breakpoint clipping

### DIFF
--- a/components/results-dashboard.tsx
+++ b/components/results-dashboard.tsx
@@ -256,7 +256,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
               <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
                 Board refreshes automatically every {Math.round(autoRefreshIntervalMs / 1000)} seconds while this tab is active.
               </p>
-              <div className="grid gap-3 min-[430px]:grid-cols-3">
+              <div className="grid gap-3 min-[560px]:grid-cols-2">
                 <div
                   data-testid="progress-stat-entries"
                   className="flex min-h-[132px] flex-col justify-between rounded-[1.55rem] border border-border/80 bg-radix-gray-a-3 p-4"
@@ -288,7 +288,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                 <div
                   data-testid="progress-stat-state"
                   className={cn(
-                    "flex min-h-[132px] flex-col justify-between rounded-[1.55rem] border p-4",
+                    "flex min-h-[132px] flex-col justify-between rounded-[1.55rem] border p-4 min-[560px]:col-span-2",
                     stateMeta.accentClassName
                   )}
                 >

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -81,6 +81,48 @@ Result:
 
 - Pass
 
+## Intermediate breakpoint scoreboard proof
+
+Date: `2026-03-24`
+
+Goal:
+
+- Prove the judging-progress cards stay contained at the in-between widths where the live site previously clipped
+
+Local validation:
+
+```bash
+pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
+```
+
+Viewports covered:
+
+- `480px`
+- `560px`
+- `768px`
+- `1575px`
+
+Proof contract:
+
+- No horizontal page overflow
+- State card remains inside the viewport
+- State label keeps healthy top and bottom inset inside the card
+- Mid-width layouts use a two-up row with a full-width state card instead of forcing three narrow columns
+
+Artifacts:
+
+- `artifacts/manual-proof/gh-14/local-fresh-480.png`
+- `artifacts/manual-proof/gh-14/local-fresh-560.png`
+- `artifacts/manual-proof/gh-14/local-fresh-768.png`
+- `artifacts/manual-proof/gh-14/local-fresh-1575.png`
+- `artifacts/manual-proof/gh-14/live-progress-480.png`
+- `artifacts/manual-proof/gh-14/live-progress-560.png`
+- `artifacts/manual-proof/gh-14/live-progress-1575.png`
+
+Result:
+
+- Pass
+
 ## Event-day readiness proof
 
 Date: `2026-03-23`

--- a/tests/e2e/scoreboard-breakpoints.spec.ts
+++ b/tests/e2e/scoreboard-breakpoints.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "playwright/test";
+
+const viewports = [
+  { name: "mobile-tight", width: 480, height: 900, colorScheme: "dark" as const },
+  { name: "mid-width", width: 560, height: 900, colorScheme: "dark" as const },
+  { name: "tablet", width: 768, height: 1024, colorScheme: "light" as const },
+  { name: "wide-desktop", width: 1575, height: 1100, colorScheme: "light" as const }
+];
+
+test.describe("scoreboard progress rail stays coherent across breakpoints", () => {
+  for (const viewport of viewports) {
+    test(`${viewport.name} keeps the progress cards contained`, async ({ page }) => {
+      await page.emulateMedia({ colorScheme: viewport.colorScheme });
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto("/");
+
+      await expect(page.getByRole("heading", { name: "Hackathon scoreboard" })).toBeVisible();
+
+      const pageMetrics = await page.evaluate(() => ({
+        viewportWidth: window.innerWidth,
+        scrollWidth: document.documentElement.scrollWidth
+      }));
+
+      expect(pageMetrics.scrollWidth).toBe(pageMetrics.viewportWidth);
+
+      const stateMetrics = await page.locator("[data-testid='progress-stat-state']").evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        const value = element.querySelector<HTMLElement>("[data-testid='progress-stat-state-value']");
+        const valueRect = value?.getBoundingClientRect();
+
+        return {
+          cardLeft: rect.left,
+          cardRight: rect.right,
+          viewportWidth: window.innerWidth,
+          valueText: value?.textContent?.trim() ?? "",
+          valueTopInset: valueRect ? valueRect.top - rect.top : null,
+          valueBottomInset: valueRect ? rect.bottom - valueRect.bottom : null
+        };
+      });
+
+      expect(stateMetrics.cardLeft).toBeGreaterThanOrEqual(0);
+      expect(stateMetrics.cardRight).toBeLessThanOrEqual(stateMetrics.viewportWidth);
+      expect(stateMetrics.valueText.length).toBeGreaterThan(0);
+      expect(stateMetrics.valueTopInset).not.toBeNull();
+      expect(stateMetrics.valueBottomInset).not.toBeNull();
+      expect(stateMetrics.valueTopInset!).toBeGreaterThan(10);
+      expect(stateMetrics.valueBottomInset!).toBeGreaterThan(10);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- stop the progress cards from forcing a three-column row too early
- add a dedicated breakpoint-proof spec for the judging-progress rail
- record fresh local and live section-focused proof for the exact failing area

## Tickets
- Closes #14

## Validation
- pnpm check
- pnpm test
- pnpm build
- pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
- vercel --prod --yes
- live screenshots at 480px, 560px, and 1575px on `https://vote.rajeevg.com`

## Acceptance notes
- the live intermediate-width clipping reported by the user is resolved
- the progress rail now stays single-column on tight widths and reflows into a two-up plus full-width state card layout in the mid-range
- the proof artifacts now include the exact section and breakpoint band that previously escaped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the responsive layout of the judging progress statistics cards for improved display consistency across different screen widths.

* **Tests**
  * Added end-to-end testing across multiple viewport sizes to verify the statistics cards display correctly without horizontal overflow.

* **Documentation**
  * Added verification documentation confirming breakpoint coverage and layout stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->