### PR TITLE
gh-18 Refine scoreboard layout and entry controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Production-oriented single-screen hackathon voting app built with Next.js 14, Ty
 The app keeps the visual language of the original results dashboard, but the product has been simplified to one public scoreboard with an integrated manager control surface and a polished voting modal for judges.
 
 The current layout is intentionally content-first: the scoreboard and next action are prioritized above the fold, while explanatory rules live in lighter supporting panels instead of dominating the first scan.
+The screen stays single-column across viewports so the scoreboard leads and judging progress follows directly underneath it instead of competing in a side rail.
 
 ## What the app is now
 
@@ -13,6 +14,8 @@ The current layout is intentionally content-first: the scoreboard and next actio
 - Authenticated judge voting in a modal
 - Automatic self-vote blocking from uploaded team-member emails
 - Live judging progress
+- Table and horizontal bar-chart views on the same scoreboard
+- Manager-only per-entry voting open/closed controls
 - Manager-only finalization and finalized XLSX export
 - Manager-only reset button for repeatable dry runs
 - Light and dark mode
@@ -130,7 +133,8 @@ The app uses a practical judging-round rule:
 
 - judges join the denominator when they cast their first vote
 - self-vote-blocked projects are removed from that judge's denominator
-- finalization unlocks when every participating judge has scored every project they are eligible to judge
+- manager-closed projects are removed from the live denominator until reopened
+- finalization unlocks when every participating judge has scored every project that is still open and eligible for them
 
 Each judge can submit one score per project. Once submitted, that score is locked for the rest of the round.
 
@@ -163,7 +167,9 @@ The Playwright suite covers:
 - anonymous public viewing
 - manager template download
 - manager workbook upload
+- manager per-entry open / close control
 - manager begin voting
+- scoreboard table / bar-chart toggle
 - email-code judge auth
 - modal keyboard voting
 - self-vote blocking
@@ -173,6 +179,7 @@ The Playwright suite covers:
 - public finalized lock state
 - manager XLSX export
 - anonymous cross-device freshness after another judge casts a score
+- single-column ordering with judging progress below the scoreboard
 
 Cheap event-day readiness checks:
 

--- a/app/api/entries/[entryId]/voting/route.ts
+++ b/app/api/entries/[entryId]/voting/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireManagerIdentity } from "@/lib/auth";
+import { setEntryVotingAvailability } from "@/lib/competition";
+
+const payloadSchema = z.object({
+  isVotingOpen: z.boolean()
+});
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { entryId: string } }
+) {
+  try {
+    await requireManagerIdentity();
+    const json = await request.json();
+    const payload = payloadSchema.parse(json);
+
+    await setEntryVotingAvailability({
+      entryId: params.entryId,
+      isVotingOpen: payload.isVotingOpen
+    });
+
+    return NextResponse.json({
+      ok: true
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Could not update project voting."
+      },
+      { status: 403 }
+    );
+  }
+}

--- a/components/results-dashboard.tsx
+++ b/components/results-dashboard.tsx
@@ -30,20 +30,23 @@ function statusCopy(status: CompetitionSnapshot["status"]) {
   if (status === "PREPARING") {
     return {
       eyebrow: "Manager setup",
-      body: "Load the workbook, sanity-check the field, and open judging when the room is ready."
+      headline: "Load the workbook, tighten the field, then open judging.",
+      body: "The scoreboard is already public. Use the controls below to upload entries, close any project that should stay out of the round, and start only when the room is ready."
     };
   }
 
   if (status === "OPEN") {
     return {
-      eyebrow: "Judging live",
-      body: "The public board stays live while signed-in judges cast their one locked score from the modal."
+      eyebrow: "Voting live",
+      headline: "The scoreboard is the room's shared source of truth.",
+      body: "Judges can sign in and cast one locked score on each project that is still open for voting. Closed projects stay visible on the board, but they stop taking new votes."
     };
   }
 
   return {
     eyebrow: "Finalized",
-    body: "Judging is complete. The standings are locked and the manager can export the official workbook."
+    headline: "The final standings are locked in.",
+    body: "Judging is complete. Everyone sees the same final scoreboard, and the manager can export the official results workbook."
   };
 }
 
@@ -51,7 +54,7 @@ function progressStateMeta(status: CompetitionSnapshot["status"]) {
   if (status === "PREPARING") {
     return {
       label: "Preparing",
-      detail: "Workbook loaded. Waiting for the manager to open judging.",
+      detail: "Workbook loaded and waiting for the manager to open judging.",
       accentClassName:
         "border-[rgb(217_140_20_/_0.2)] bg-[rgb(217_140_20_/_0.08)] text-foreground"
     };
@@ -60,99 +63,45 @@ function progressStateMeta(status: CompetitionSnapshot["status"]) {
   if (status === "OPEN") {
     return {
       label: "Voting live",
-      detail: "Judges can cast one locked vote per project while the board updates in public.",
+      detail: "Only projects marked open continue to count toward round completion.",
       accentClassName: "border-radix-teal-a-6 bg-radix-teal-a-3 text-accent-foreground"
     };
   }
 
   return {
     label: "Finalized",
-    detail: "Scores are locked, the board is final, and export is ready.",
+    detail: "Scores are locked and export is ready.",
     accentClassName: "border-radix-purple-a-5 bg-radix-purple-a-4 text-foreground"
-  };
-}
-
-function nextActionMeta(snapshot: CompetitionSnapshot, isEmpty: boolean) {
-  if (snapshot.status === "FINALIZED") {
-    return snapshot.viewer.isManager
-      ? {
-          title: "Export the final workbook",
-          detail: "The public result is locked now. Download the official export when you need the final scores."
-        }
-      : {
-          title: "Review the final standings",
-          detail: "Voting is closed. Use the board to review the finished ranking and aggregate scores."
-        };
-  }
-
-  if (snapshot.status === "OPEN") {
-    if (!snapshot.viewer.isAuthenticated) {
-      return {
-        title: "Sign in to judge",
-        detail: "Open any project row, sign in once, and cast your one locked vote where you are eligible."
-      };
-    }
-
-    if (snapshot.viewer.isManager) {
-      return {
-        title: "Monitor coverage and finalize",
-        detail: "Watch completion in the right rail and finalize as soon as every participating judge has covered every eligible project."
-      };
-    }
-
-    return {
-      title: "Open a row and score it",
-      detail: "Choose a project from the board, score it once in the modal, and move on."
-    };
-  }
-
-  if (snapshot.viewer.isManager) {
-    return snapshot.canUploadSheet
-      ? {
-          title: isEmpty ? "Upload the judging workbook" : "Review the board, then begin voting",
-          detail: isEmpty
-            ? "Download the template, fill one row per project, and upload it to populate the board."
-            : "The board is populated. Confirm the entries look right, then open judging when the room is ready."
-        }
-      : {
-          title: "Reset to replace the workbook",
-          detail: "Voting has already moved forward. Reset the dry run if you need to upload a different workbook."
-        };
-  }
-
-  return {
-    title: "Watch the board until judging opens",
-    detail: "Everyone can view the board immediately. Voting unlocks once the manager opens the round."
   };
 }
 
 function scoreboardCopy(snapshot: CompetitionSnapshot, isEmpty: boolean) {
   if (isEmpty) {
     return {
-      title: "Workbook-driven scoreboard",
+      title: "No projects loaded yet",
       detail: snapshot.viewer.isManager
-        ? "Use the manager rail to load the XLSX. The board stays intentionally empty until real judging data is uploaded."
+        ? "Upload the workbook to bring the board to life. Nothing shows here until the real XLSX is loaded."
         : "The board stays intentionally empty until the manager uploads the judging workbook."
     };
   }
 
   if (snapshot.status === "PREPARING") {
     return {
-      title: "Field loaded and ready for review",
-      detail: "The public board is already visible, and the manager can still replace the workbook before opening voting."
+      title: "Review the field before judges arrive",
+      detail: "The board is live already. Managers can still close or reopen individual projects before opening the round."
     };
   }
 
   if (snapshot.status === "OPEN") {
     return {
       title: "Live standings",
-      detail: "The ranking updates in public as judges score. Open a row to vote, or use the board to see why a project is locked for you."
+      detail: "Use the table or bar chart to track the ranking, then open a project row to inspect or vote."
     };
   }
 
   return {
     title: "Final standings",
-    detail: "The public scoreboard is locked. Open a row to inspect the final project details and voting state."
+    detail: "The public board is now locked in its final order."
   };
 }
 
@@ -160,6 +109,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
   const router = useRouter();
   const [selectedEntry, setSelectedEntry] = React.useState<ScoreboardEntryView | null>(null);
   const [pendingAction, startTransition] = React.useTransition();
+  const [pendingEntryId, setPendingEntryId] = React.useState<string | null>(null);
   const [uploadState, setUploadState] = React.useState<{
     status: "idle" | "uploading" | "success" | "error";
     message: string | null;
@@ -176,14 +126,14 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
   const copy = statusCopy(snapshot.status);
   const stateMeta = progressStateMeta(snapshot.status);
   const isEmpty = snapshot.entries.length === 0;
-  const nextAction = nextActionMeta(snapshot, isEmpty);
   const scoreboardMeta = scoreboardCopy(snapshot, isEmpty);
   const autoRefreshIntervalMs = snapshot.status === "OPEN" ? 5000 : 15000;
   const autoRefreshPaused =
     Boolean(selectedEntry) ||
     authDialogOpen ||
     uploadState.status === "uploading" ||
-    pendingAction;
+    pendingAction ||
+    Boolean(pendingEntryId);
 
   React.useEffect(() => {
     if (snapshot.viewer.isAuthenticated) return;
@@ -219,14 +169,22 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
     };
   }, [autoRefreshIntervalMs, autoRefreshPaused, router, startTransition]);
 
-  async function postJson(url: string) {
+  async function sendJson(url: string, init?: RequestInit) {
     const response = await fetch(url, {
-      method: "POST"
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...(init?.headers ?? {})
+      }
     });
     const payload = await response.json().catch(() => ({}));
     if (!response.ok) {
       throw new Error(payload.error ?? "The action could not be completed.");
     }
+  }
+
+  async function postJson(url: string) {
+    return sendJson(url, { method: "POST" });
   }
 
   async function handleWorkbookUpload(file: File) {
@@ -262,6 +220,27 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
     refreshBoard();
   }
 
+  async function handleEntryVotingToggle(entry: ScoreboardEntryView) {
+    try {
+      setPendingEntryId(entry.id);
+      setActionMessage(null);
+      await sendJson(`/api/entries/${entry.id}/voting`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          isVotingOpen: !entry.isVotingOpen
+        })
+      });
+      setActionMessage(
+        `${entry.projectName} is now ${entry.isVotingOpen ? "closed to new votes." : "open for judging again."}`
+      );
+      refreshBoard();
+    } catch (error) {
+      setActionMessage(error instanceof Error ? error.message : "We could not update that project.");
+    } finally {
+      setPendingEntryId(null);
+    }
+  }
+
   function openWorkbookPicker() {
     if (!snapshot.canUploadSheet || uploadState.status === "uploading") return;
     uploadInputRef.current?.click();
@@ -269,7 +248,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
 
   return (
     <div className="min-h-screen">
-      <main className="container space-y-6 py-6 sm:space-y-8 sm:py-8">
+      <main className="container space-y-5 py-6 sm:space-y-6 sm:py-8">
         <section className="glass-panel flex flex-col gap-5 rounded-[2rem] px-5 py-5 sm:px-6">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div className="flex items-center gap-4">
@@ -304,235 +283,138 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
           </div>
         </section>
 
-        <section className="grid gap-6 xl:grid-cols-[minmax(0,1.58fr)_minmax(320px,0.84fr)]">
-          <div className="space-y-4">
-            <div className="glass-panel shell-surface rounded-[2rem] px-4 py-4 sm:px-6 sm:py-5" data-testid="workflow-summary">
-              <div className="space-y-5">
-                <div className="max-w-3xl">
-                  <div className="eyebrow">{copy.eyebrow}</div>
-                  <h1 className="mt-3 font-display text-[clamp(2rem,3vw,3rem)] font-black tracking-tight text-foreground">
-                    Live hackathon scoreboard
-                  </h1>
-                  <p className="mt-3 text-sm leading-7 text-muted-foreground sm:text-base sm:leading-8">
-                    {copy.body}
-                  </p>
-                </div>
-                <div className="grid gap-3 min-[520px]:grid-cols-2 xl:grid-cols-3">
-                  <div className="rounded-[1.45rem] border border-border/80 bg-radix-gray-a-3/90 p-4">
-                    <div className="eyebrow">Current mode</div>
-                    <div className="mt-3 font-display text-xl font-black leading-tight text-foreground sm:text-2xl">
-                      {stateMeta.label}
-                    </div>
-                    <p className="mt-2 text-sm leading-6 text-muted-foreground">{stateMeta.detail}</p>
-                  </div>
-                  <div className="rounded-[1.45rem] border border-border/80 bg-radix-gray-a-3/90 p-4">
-                    <div className="eyebrow">Next move</div>
-                    <div className="mt-3 text-base font-semibold text-foreground">{nextAction.title}</div>
-                    <p className="mt-2 text-sm leading-6 text-muted-foreground">{nextAction.detail}</p>
-                  </div>
-                  <div className="hidden rounded-[1.45rem] border border-border/80 bg-radix-gray-a-3/90 p-4 xl:block">
-                    <div className="eyebrow">Guardrails</div>
-                    <div className="mt-3 text-base font-semibold text-foreground">One locked vote, no self-scoring</div>
-                    <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                      One vote per project. Uploaded team emails block self-votes automatically.
-                    </p>
-                  </div>
-                </div>
-              </div>
+        <section className="space-y-4" data-testid="workflow-summary">
+          <div className="glass-panel shell-surface rounded-[2rem] px-5 py-5 sm:px-6 sm:py-6">
+            <div className="max-w-4xl">
+              <div className="eyebrow">{copy.eyebrow}</div>
+              <h1 className="mt-3 font-display text-[clamp(2rem,4vw,3.35rem)] font-black tracking-tight text-foreground">
+                Live hackathon scoreboard
+              </h1>
+              <p className="mt-3 text-base leading-8 text-foreground/90">{copy.headline}</p>
+              <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground">{copy.body}</p>
             </div>
 
-            <div className="space-y-3" data-testid="scoreboard-section">
-              <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-                <div className="max-w-2xl">
-                  <div className="eyebrow">Scoreboard</div>
-                  <h2 className="font-display text-2xl font-black">{scoreboardMeta.title}</h2>
-                  <p className="mt-2 text-sm leading-7 text-muted-foreground">{scoreboardMeta.detail}</p>
-                </div>
-                <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                  <span className="rounded-full bg-radix-teal-a-3 px-3 py-2 text-accent-foreground">
-                    Public board
-                  </span>
-                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                    {snapshot.progress.entryCount} entr{snapshot.progress.entryCount === 1 ? "y" : "ies"}
-                  </span>
-                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                    {snapshot.status === "OPEN" ? "Judging live" : snapshot.status === "FINALIZED" ? "Results locked" : "Waiting to open"}
-                  </span>
-                </div>
-              </div>
-              <ResultsScoreboardTable
-                entries={snapshot.entries}
-                onSelectEntry={setSelectedEntry}
-                status={snapshot.status}
-                viewer={snapshot.viewer}
-              />
+            <div className="mt-5 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              <span className="rounded-full bg-radix-teal-a-3 px-3 py-2 text-accent-foreground">Public board</span>
+              <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                {snapshot.progress.entryCount} entr{snapshot.progress.entryCount === 1 ? "y" : "ies"}
+              </span>
+              <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                {snapshot.progress.openEntryCount} open for voting
+              </span>
+              <span
+                className={cn(
+                  "rounded-full px-3 py-2",
+                  snapshot.status === "OPEN"
+                    ? "bg-radix-teal-a-3 text-accent-foreground"
+                    : snapshot.status === "FINALIZED"
+                      ? "bg-radix-purple-a-4 text-foreground"
+                      : "bg-radix-amber-a-3 text-foreground"
+                )}
+              >
+                {stateMeta.label}
+              </span>
             </div>
           </div>
 
-          <div className="space-y-4">
+          {snapshot.viewer.isManager ? (
             <Card className="glass-panel rounded-[2rem] border-0 bg-transparent shadow-none">
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base">Judging progress</CardTitle>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">Manager controls</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="flex flex-wrap items-end justify-between gap-4">
-                  <div className="flex items-end gap-3">
-                    <div className="font-display text-5xl font-black text-primary">{snapshot.progress.percentage}%</div>
-                    <div className="pb-2 text-sm font-semibold text-muted-foreground">
-                      {snapshot.progress.castVotes}/
-                      {snapshot.progress.expectedVotes || snapshot.progress.entryCount}
+                <div className="flex flex-col gap-4 rounded-[1.6rem] border border-border/80 bg-radix-gray-a-3/80 p-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="max-w-2xl">
+                    <div className="eyebrow">Manager workflow</div>
+                    <div className="mt-2 text-lg font-semibold text-foreground">
+                      Download the template, upload the workbook, then control the field from the scoreboard itself.
                     </div>
-                  </div>
-                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                    Refreshes every {Math.round(autoRefreshIntervalMs / 1000)}s
-                  </span>
-                </div>
-                <Progress value={snapshot.progress.percentage} />
-                <p className="text-sm leading-7 text-muted-foreground">{snapshot.progress.helperText}</p>
-                <div className="grid gap-3 min-[560px]:grid-cols-2">
-                  <div
-                    data-testid="progress-stat-entries"
-                    className="flex min-h-[132px] flex-col justify-between rounded-[1.55rem] border border-border/80 bg-radix-gray-a-3 p-4"
-                  >
-                    <div className="eyebrow">Entries</div>
-                    <div
-                      data-testid="progress-stat-entries-value"
-                      className="mt-4 font-display text-[1.85rem] font-black leading-[0.95] tracking-tight sm:text-[2rem]"
-                    >
-                      {snapshot.progress.entryCount}
-                    </div>
-                    <p className="mt-4 text-xs leading-5 text-muted-foreground">Projects currently shown on the board.</p>
-                  </div>
-                  <div
-                    data-testid="progress-stat-judges"
-                    className="flex min-h-[132px] flex-col justify-between rounded-[1.55rem] border border-border/80 bg-radix-gray-a-3 p-4"
-                  >
-                    <div className="eyebrow">Judges in round</div>
-                    <div
-                      data-testid="progress-stat-judges-value"
-                      className="mt-4 font-display text-[1.85rem] font-black leading-[0.95] tracking-tight sm:text-[2rem]"
-                    >
-                      {snapshot.progress.participatingJudgeCount}
-                    </div>
-                    <p className="mt-4 text-xs leading-5 text-muted-foreground">
-                      The denominator only counts judges who have started scoring.
+                    <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                      Every row below now has its own voting-open state. Closed projects remain public on the board, but judges cannot add new votes until you reopen them.
                     </p>
                   </div>
-                  <div
-                    data-testid="progress-stat-state"
-                    className={cn(
-                      "flex min-h-[132px] flex-col justify-between rounded-[1.55rem] border p-4 min-[560px]:col-span-2",
-                      stateMeta.accentClassName
-                    )}
-                  >
-                    <div className="eyebrow">State</div>
-                    <div
-                      data-testid="progress-stat-state-value"
-                      className="mt-4 font-display text-[1.6rem] font-black leading-[1.02] tracking-tight sm:text-[1.85rem]"
-                    >
-                      {stateMeta.label}
-                    </div>
-                    <p className="mt-4 text-xs leading-5 opacity-90">{stateMeta.detail}</p>
+                  <div className="flex flex-wrap gap-3">
+                    <Button asChild size="sm" variant="outline">
+                      <a data-testid="manager-download-template" href="/api/template">
+                        <FileSpreadsheet className="h-4 w-4" />
+                        Download template
+                        <ArrowUpRight className="h-4 w-4" />
+                      </a>
+                    </Button>
+                    {snapshot.canDownloadFinalizedExport ? (
+                      <Button asChild size="sm">
+                        <a data-testid="manager-export-results" href="/api/export">
+                          Export finalized scores
+                          <ArrowUpRight className="h-4 w-4" />
+                        </a>
+                      </Button>
+                    ) : null}
                   </div>
                 </div>
-              </CardContent>
-            </Card>
 
-            <Card className="glass-panel rounded-[2rem] border-0 bg-transparent shadow-none">
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base">{snapshot.viewer.isManager ? "Manager controls" : "Judge access"}</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {snapshot.viewer.isManager ? (
-                  <>
-                    <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4">
-                      <div className="eyebrow">Primary setup</div>
-                      <div className="mt-3 flex items-center gap-2 text-sm font-semibold text-foreground">
-                        <FileSpreadsheet className="h-4 w-4 text-primary" />
-                        Download, upload, then open judging
-                      </div>
-                      <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                        Keep one project per row, use unique project names, and include team emails so self-voting can be blocked automatically.
-                      </p>
-                      <div className="mt-4 flex flex-wrap gap-3">
-                        <Button asChild size="sm" variant="outline">
-                          <a data-testid="manager-download-template" href="/api/template">
-                            Download template
-                            <ArrowUpRight className="h-4 w-4" />
-                          </a>
-                        </Button>
-                        {snapshot.canDownloadFinalizedExport ? (
-                          <Button asChild size="sm">
-                            <a data-testid="manager-export-results" href="/api/export">
-                              Export finalized scores
-                              <ArrowUpRight className="h-4 w-4" />
-                            </a>
-                          </Button>
-                        ) : null}
+                <div
+                  className={cn(
+                    "rounded-[1.6rem] border border-dashed p-5 transition",
+                    isDragOver
+                      ? "border-radix-teal-a-7 bg-radix-teal-a-3"
+                      : "border-radix-teal-a-6 bg-radix-teal-a-2 hover:border-radix-teal-a-7 hover:bg-radix-teal-a-3"
+                  )}
+                  data-testid="manager-upload-dropzone"
+                  onClick={openWorkbookPicker}
+                  onDragLeave={() => setIsDragOver(false)}
+                  onDragOver={(event) => {
+                    event.preventDefault();
+                    setIsDragOver(true);
+                  }}
+                  onDrop={(event) => {
+                    event.preventDefault();
+                    setIsDragOver(false);
+                    if (!snapshot.canUploadSheet || uploadState.status === "uploading") return;
+                    const file = event.dataTransfer.files?.[0];
+                    if (file) void handleWorkbookUpload(file);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      openWorkbookPicker();
+                    }
+                  }}
+                  role="button"
+                  tabIndex={snapshot.canUploadSheet ? 0 : -1}
+                >
+                  <input
+                    accept=".xlsx"
+                    className="sr-only"
+                    disabled={!snapshot.canUploadSheet || uploadState.status === "uploading"}
+                    ref={uploadInputRef}
+                    onChange={(event) => {
+                      const file = event.target.files?.[0];
+                      if (file) void handleWorkbookUpload(file);
+                      event.currentTarget.value = "";
+                    }}
+                    type="file"
+                  />
+
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex items-center gap-3">
+                      <ShieldCheck className="h-5 w-5 text-primary" />
+                      <div>
+                        <div className="font-semibold text-foreground">Drag, drop, or choose a workbook</div>
+                        <div className="text-sm text-muted-foreground">
+                          {snapshot.canUploadSheet
+                            ? "Upload is available now."
+                            : "Upload unlocks again after you reset the round back to manager setup."}
+                        </div>
                       </div>
                     </div>
-
-                    <div
-                      className={`rounded-[1.5rem] border border-dashed p-5 transition ${
-                        isDragOver
-                          ? "border-radix-teal-a-7 bg-radix-teal-a-3"
-                          : "border-radix-teal-a-6 bg-radix-teal-a-2 hover:border-radix-teal-a-7 hover:bg-radix-teal-a-3"
-                      }`}
-                      data-testid="manager-upload-dropzone"
-                      onClick={openWorkbookPicker}
-                      onDragLeave={() => setIsDragOver(false)}
-                      onDragOver={(event) => {
-                        event.preventDefault();
-                        setIsDragOver(true);
+                    <Button
+                      data-testid="manager-upload-button"
+                      disabled={!snapshot.canUploadSheet || uploadState.status === "uploading"}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        openWorkbookPicker();
                       }}
-                      onDrop={(event) => {
-                        event.preventDefault();
-                        setIsDragOver(false);
-                        if (!snapshot.canUploadSheet || uploadState.status === "uploading") return;
-                        const file = event.dataTransfer.files?.[0];
-                        if (file) void handleWorkbookUpload(file);
-                      }}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter" || event.key === " ") {
-                          event.preventDefault();
-                          openWorkbookPicker();
-                        }
-                      }}
-                      role="button"
-                      tabIndex={snapshot.canUploadSheet ? 0 : -1}
-                    >
-                      <input
-                        accept=".xlsx"
-                        className="sr-only"
-                        disabled={!snapshot.canUploadSheet || uploadState.status === "uploading"}
-                        ref={uploadInputRef}
-                        onChange={(event) => {
-                          const file = event.target.files?.[0];
-                          if (file) void handleWorkbookUpload(file);
-                          event.currentTarget.value = "";
-                        }}
-                        type="file"
-                      />
-                      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                        <div className="flex items-center gap-3">
-                          <ShieldCheck className="h-5 w-5 text-primary" />
-                          <div>
-                            <div className="font-semibold text-foreground">Drag, drop, or choose a workbook</div>
-                            <div className="text-sm text-muted-foreground">
-                              {snapshot.canUploadSheet
-                                ? "Upload is available now."
-                                : "Upload unlocks again after you reset the round back to manager setup."}
-                            </div>
-                          </div>
-                        </div>
-                        <Button
-                          data-testid="manager-upload-button"
-                          disabled={!snapshot.canUploadSheet || uploadState.status === "uploading"}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            openWorkbookPicker();
-                          }}
-                          size="sm"
+                      size="sm"
                       type="button"
                       variant="outline"
                     >
@@ -542,138 +424,107 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                   </div>
                 </div>
 
-                    {uploadState.message ? (
-                      <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4 text-sm text-muted-foreground">
-                        {uploadState.message}
-                      </div>
-                    ) : null}
+                {uploadState.message ? (
+                  <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4 text-sm text-muted-foreground">
+                    {uploadState.message}
+                  </div>
+                ) : null}
 
-                    {snapshot.viewer.isManager && isEmpty && uploadState.status === "idle" ? (
-                      <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4 text-sm leading-6 text-muted-foreground">
-                        No workbook is loaded right now. Uploading here is the fastest way to bring the public scoreboard to life.
-                      </div>
-                    ) : null}
+                {snapshot.viewer.isManager && isEmpty && uploadState.status === "idle" ? (
+                  <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4 text-sm leading-6 text-muted-foreground">
+                    No workbook is loaded right now. Uploading here is the fastest way to bring the public scoreboard to life.
+                  </div>
+                ) : null}
 
-                    {uploadState.issues.length ? (
-                      <div className="rounded-[1.5rem] border border-[rgb(204_63_79_/_0.25)] bg-[rgb(204_63_79_/_0.08)] p-4">
-                        <div className="font-semibold text-foreground">Workbook issues</div>
-                        <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
-                          {uploadState.issues.map((issue) => (
-                            <li key={`${issue.rowNumber}-${issue.field}-${issue.message}`}>
-                              Row {issue.rowNumber}: {issue.message}
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
-                    ) : null}
+                {uploadState.issues.length ? (
+                  <div className="rounded-[1.5rem] border border-[rgb(204_63_79_/_0.25)] bg-[rgb(204_63_79_/_0.08)] p-4">
+                    <div className="font-semibold text-foreground">Workbook issues</div>
+                    <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+                      {uploadState.issues.map((issue) => (
+                        <li key={`${issue.rowNumber}-${issue.field}-${issue.message}`}>
+                          Row {issue.rowNumber}: {issue.message}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
 
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      <Button
-                        data-testid="manager-begin-voting"
-                        disabled={!snapshot.canBeginVoting || pendingAction}
-                        onClick={() =>
-                          void (async () => {
-                            try {
-                              setActionMessage(null);
-                              await postJson("/api/competition/start");
-                              refreshBoard();
-                            } catch (error) {
-                              setActionMessage(
-                                error instanceof Error ? error.message : "We could not begin voting."
-                              );
-                            }
-                          })()
+                <div className="grid gap-3 lg:grid-cols-3">
+                  <Button
+                    data-testid="manager-begin-voting"
+                    disabled={!snapshot.canBeginVoting || pendingAction}
+                    onClick={() =>
+                      void (async () => {
+                        try {
+                          setActionMessage(null);
+                          await postJson("/api/competition/start");
+                          refreshBoard();
+                        } catch (error) {
+                          setActionMessage(error instanceof Error ? error.message : "We could not begin voting.");
                         }
-                      >
-                        {pendingAction ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
-                        Begin voting
-                      </Button>
-                      <Button
-                        data-testid="manager-finalize"
-                        disabled={!snapshot.canFinalize || pendingAction}
-                        onClick={() =>
-                          void (async () => {
-                            try {
-                              setActionMessage(null);
-                              await postJson("/api/competition/finalize");
-                              refreshBoard();
-                            } catch (error) {
-                              setActionMessage(
-                                error instanceof Error ? error.message : "We could not finalize the round."
-                              );
-                            }
-                          })()
+                      })()
+                    }
+                  >
+                    {pendingAction ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+                    Begin voting
+                  </Button>
+                  <Button
+                    data-testid="manager-finalize"
+                    disabled={!snapshot.canFinalize || pendingAction}
+                    onClick={() =>
+                      void (async () => {
+                        try {
+                          setActionMessage(null);
+                          await postJson("/api/competition/finalize");
+                          refreshBoard();
+                        } catch (error) {
+                          setActionMessage(
+                            error instanceof Error ? error.message : "We could not finalize the round."
+                          );
                         }
-                        variant="secondary"
-                      >
-                        <Flag className="h-4 w-4" />
-                        Finalize scores
-                      </Button>
-                    </div>
+                      })()
+                    }
+                    variant="secondary"
+                  >
+                    <Flag className="h-4 w-4" />
+                    Finalize scores
+                  </Button>
+                  <Button
+                    data-testid="manager-reset-round"
+                    disabled={!snapshot.canResetRound || pendingAction || uploadState.status === "uploading"}
+                    onClick={() => {
+                      if (
+                        !window.confirm(
+                          "Reset the round and remove the current workbook, votes, and judging state?"
+                        )
+                      ) {
+                        return;
+                      }
 
-                    <Button
-                      data-testid="manager-reset-round"
-                      disabled={!snapshot.canResetRound || pendingAction || uploadState.status === "uploading"}
-                      onClick={() => {
-                        if (
-                          !window.confirm(
-                            "Reset the round and remove the current workbook, votes, and judging state?"
-                          )
-                        ) {
-                          return;
+                      void (async () => {
+                        try {
+                          setActionMessage(null);
+                          setUploadState({
+                            status: "idle",
+                            message: null,
+                            issues: []
+                          });
+                          await postJson("/api/competition/reset");
+                          setActionMessage("Competition reset. Upload a fresh workbook to start the next dry run.");
+                          refreshBoard();
+                        } catch (error) {
+                          setActionMessage(error instanceof Error ? error.message : "We could not reset the round.");
                         }
-
-                        void (async () => {
-                          try {
-                            setActionMessage(null);
-                            setUploadState({
-                              status: "idle",
-                              message: null,
-                              issues: []
-                            });
-                            await postJson("/api/competition/reset");
-                            setActionMessage("Competition reset. Upload a fresh workbook to start the next dry run.");
-                            refreshBoard();
-                          } catch (error) {
-                            setActionMessage(
-                              error instanceof Error ? error.message : "We could not reset the round."
-                            );
-                          }
-                        })();
-                      }}
-                      size="sm"
-                      type="button"
-                      variant="destructive"
-                    >
-                      <RotateCcw className="h-4 w-4" />
-                      Reset dry run
-                    </Button>
-                  </>
-                ) : (
-                  <>
-                    <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4">
-                      <div className="eyebrow">Next move</div>
-                      <div className="mt-2 text-base font-semibold text-foreground">{nextAction.title}</div>
-                      <p className="mt-2 text-sm leading-6 text-muted-foreground">{nextAction.detail}</p>
-                    </div>
-                    <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4 text-sm leading-6 text-muted-foreground">
-                      Anyone can view the board. Judges sign in once, cast one score per project from the modal, and that score stays locked unless the manager resets the whole round.
-                    </div>
-                    <div className="rounded-[1.5rem] border border-border bg-radix-gray-a-3 p-4 text-sm leading-6 text-muted-foreground">
-                      Self-voting is blocked from uploaded team emails, and completion only counts entries a given judge is actually allowed to score.
-                    </div>
-                    <SignedOut>
-                      <Button
-                        className="w-full justify-center"
-                        data-testid="judge-auth-open-secondary"
-                        onClick={() => setAuthDialogOpen(true)}
-                        size="lg"
-                      >
-                        Sign in to judge
-                      </Button>
-                    </SignedOut>
-                  </>
-                )}
+                      })();
+                    }}
+                    size="sm"
+                    type="button"
+                    variant="destructive"
+                  >
+                    <RotateCcw className="h-4 w-4" />
+                    Reset dry run
+                  </Button>
+                </div>
 
                 {actionMessage ? (
                   <div className="rounded-[1.5rem] border border-[rgb(204_63_79_/_0.25)] bg-[rgb(204_63_79_/_0.08)] p-4 text-sm text-foreground">
@@ -682,31 +533,112 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                 ) : null}
               </CardContent>
             </Card>
-          </div>
-        </section>
+          ) : null}
 
-        <section className="grid gap-4 lg:grid-cols-3">
-          <div className="glass-panel rounded-[1.8rem] p-5">
-            <div className="eyebrow">Public board</div>
-            <h3 className="mt-2 font-display text-2xl font-black">Everyone sees the same ranking</h3>
-            <p className="mt-3 text-sm leading-7 text-muted-foreground">
-              The main route is always public and read-only, so people can follow the standings without signing in.
-            </p>
-          </div>
-          <div className="glass-panel rounded-[1.8rem] p-5">
-            <div className="eyebrow">Judge flow</div>
-            <h3 className="mt-2 font-display text-2xl font-black">One vote, then it locks</h3>
-            <p className="mt-3 text-sm leading-7 text-muted-foreground">
-              Judges open a project row, score it once in the modal, and the board immediately reflects the new aggregate.
-            </p>
-          </div>
-          <div className="glass-panel rounded-[1.8rem] p-5">
-            <div className="eyebrow">Completion</div>
-            <h3 className="mt-2 font-display text-2xl font-black">Finalize only when coverage is complete</h3>
-            <p className="mt-3 text-sm leading-7 text-muted-foreground">
-              The round can close only after every participating judge has scored every project they are eligible to judge.
-            </p>
-          </div>
+          <section className="space-y-3" data-testid="scoreboard-section">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="max-w-2xl">
+                <div className="eyebrow">Scoreboard</div>
+                <h2 className="font-display text-2xl font-black">{scoreboardMeta.title}</h2>
+                <p className="mt-2 text-sm leading-7 text-muted-foreground">{scoreboardMeta.detail}</p>
+              </div>
+              <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                  {snapshot.progress.participatingJudgeCount} judging now
+                </span>
+                <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                  {snapshot.progress.openEntryCount} project{snapshot.progress.openEntryCount === 1 ? "" : "s"} open
+                </span>
+              </div>
+            </div>
+
+            <ResultsScoreboardTable
+              entries={snapshot.entries}
+              onSelectEntry={setSelectedEntry}
+              onToggleEntryVoting={snapshot.viewer.isManager ? handleEntryVotingToggle : undefined}
+              pendingEntryId={pendingEntryId}
+              status={snapshot.status}
+              viewer={snapshot.viewer}
+            />
+          </section>
+
+          <Card className="glass-panel rounded-[2rem] border-0 bg-transparent shadow-none" data-testid="progress-panel">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">Judging progress</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                <div className="flex flex-wrap items-end gap-4">
+                  <div className="font-display text-5xl font-black text-primary">{snapshot.progress.percentage}%</div>
+                  <div className="pb-2 text-sm font-semibold text-muted-foreground">
+                    {snapshot.progress.castVotes}/{snapshot.progress.expectedVotes}
+                  </div>
+                </div>
+                <div className="max-w-2xl text-sm leading-7 text-muted-foreground">
+                  {snapshot.progress.helperText}
+                </div>
+              </div>
+              <Progress value={snapshot.progress.percentage} />
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                <div
+                  data-testid="progress-stat-entries"
+                  className="rounded-[1.45rem] border border-border/80 bg-radix-gray-a-3 p-4"
+                >
+                  <div className="eyebrow">Entries</div>
+                  <div
+                    data-testid="progress-stat-entries-value"
+                    className="mt-3 font-display text-[1.85rem] font-black leading-[1] tracking-tight"
+                  >
+                    {snapshot.progress.entryCount}
+                  </div>
+                  <p className="mt-3 text-xs leading-5 text-muted-foreground">Projects currently shown on the board.</p>
+                </div>
+                <div className="rounded-[1.45rem] border border-border/80 bg-radix-gray-a-3 p-4">
+                  <div className="eyebrow">Open now</div>
+                  <div className="mt-3 font-display text-[1.85rem] font-black leading-[1] tracking-tight">
+                    {snapshot.progress.openEntryCount}
+                  </div>
+                  <p className="mt-3 text-xs leading-5 text-muted-foreground">
+                    Only open projects accept new votes and count toward completion.
+                  </p>
+                </div>
+                <div
+                  data-testid="progress-stat-judges"
+                  className="rounded-[1.45rem] border border-border/80 bg-radix-gray-a-3 p-4"
+                >
+                  <div className="eyebrow">Judges in round</div>
+                  <div
+                    data-testid="progress-stat-judges-value"
+                    className="mt-3 font-display text-[1.85rem] font-black leading-[1] tracking-tight"
+                  >
+                    {snapshot.progress.participatingJudgeCount}
+                  </div>
+                  <p className="mt-3 text-xs leading-5 text-muted-foreground">
+                    The denominator only counts judges who have already started scoring.
+                  </p>
+                </div>
+                <div
+                  data-testid="progress-stat-state"
+                  className={cn(
+                    "rounded-[1.45rem] border p-4",
+                    stateMeta.accentClassName
+                  )}
+                >
+                  <div className="eyebrow">State</div>
+                  <div
+                    data-testid="progress-stat-state-value"
+                    className="mt-3 font-display text-[1.85rem] font-black leading-[1.02] tracking-tight"
+                  >
+                    {stateMeta.label}
+                  </div>
+                  <p className="mt-3 text-xs leading-5 opacity-90">{stateMeta.detail}</p>
+                </div>
+              </div>
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Board refreshes automatically every {Math.round(autoRefreshIntervalMs / 1000)} seconds while this tab is active.
+              </div>
+            </CardContent>
+          </Card>
         </section>
       </main>
 

--- a/components/results-scoreboard-table.tsx
+++ b/components/results-scoreboard-table.tsx
@@ -1,16 +1,20 @@
 "use client";
 
+import * as React from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { Lock, Vote } from "lucide-react";
+import { BarChart3, Lock, PauseCircle, PlayCircle, Table2, Vote } from "lucide-react";
 
 import type { ScoreboardEntryView, ViewerIdentity } from "@/lib/competition-logic";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 type ResultsScoreboardTableProps = {
   entries: ScoreboardEntryView[];
   status: "PREPARING" | "OPEN" | "FINALIZED";
   viewer: ViewerIdentity;
   onSelectEntry: (entry: ScoreboardEntryView) => void;
+  onToggleEntryVoting?: (entry: ScoreboardEntryView) => void;
+  pendingEntryId?: string | null;
 };
 
 function actionLabel({
@@ -23,23 +27,219 @@ function actionLabel({
   viewer: ViewerIdentity;
 }) {
   if (status === "FINALIZED") return "Locked";
+  if (entry.currentUserVote != null) return "Scored";
+  if (!entry.isVotingOpen) return "Closed";
   if (status === "PREPARING") return "Opens soon";
   if (entry.isSelfVoteBlocked) return "Team member";
   if (!viewer.isAuthenticated) return "Sign in";
-  return entry.currentUserVote == null ? "Vote" : "Scored";
+  return "Vote";
+}
+
+function votingStateLabel(entry: ScoreboardEntryView, status: "PREPARING" | "OPEN" | "FINALIZED") {
+  if (status === "FINALIZED") return "Final";
+  return entry.isVotingOpen ? "Open" : "Closed";
+}
+
+function ScoreboardActionButton({
+  entry,
+  status,
+  viewer,
+  onSelectEntry
+}: {
+  entry: ScoreboardEntryView;
+  status: "PREPARING" | "OPEN" | "FINALIZED";
+  viewer: ViewerIdentity;
+  onSelectEntry: (entry: ScoreboardEntryView) => void;
+}) {
+  return (
+    <Button
+      className="min-w-[118px] justify-center"
+      data-testid={`scoreboard-action-${entry.slug}`}
+      onClick={(event) => {
+        event.stopPropagation();
+        onSelectEntry(entry);
+      }}
+      size="sm"
+      type="button"
+      variant={entry.canVote ? "default" : "outline"}
+    >
+      {entry.canVote ? <Vote className="h-4 w-4" /> : <Lock className="h-4 w-4" />}
+      {actionLabel({ entry, status, viewer })}
+    </Button>
+  );
+}
+
+function ManagerVotingToggle({
+  entry,
+  status,
+  onToggleEntryVoting,
+  pendingEntryId
+}: {
+  entry: ScoreboardEntryView;
+  status: "PREPARING" | "OPEN" | "FINALIZED";
+  onToggleEntryVoting?: (entry: ScoreboardEntryView) => void;
+  pendingEntryId?: string | null;
+}) {
+  if (!onToggleEntryVoting) return null;
+
+  return (
+    <Button
+      data-testid={`manager-entry-toggle-${entry.slug}`}
+      disabled={status === "FINALIZED" || pendingEntryId === entry.id}
+      onClick={(event) => {
+        event.stopPropagation();
+        onToggleEntryVoting(entry);
+      }}
+      size="sm"
+      type="button"
+      variant="outline"
+    >
+      {entry.isVotingOpen ? <PauseCircle className="h-4 w-4" /> : <PlayCircle className="h-4 w-4" />}
+      {entry.isVotingOpen ? "Close voting" : "Reopen voting"}
+    </Button>
+  );
+}
+
+function EntryMetaPills({
+  entry,
+  status
+}: {
+  entry: ScoreboardEntryView;
+  status: "PREPARING" | "OPEN" | "FINALIZED";
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <span className="rounded-full bg-radix-gray-a-3 px-3 py-1 text-xs font-semibold text-muted-foreground">
+        {entry.voteCount} vote{entry.voteCount === 1 ? "" : "s"}
+      </span>
+      <span
+        className={cn(
+          "rounded-full px-3 py-1 text-xs font-semibold",
+          entry.isVotingOpen
+            ? "bg-radix-teal-a-3 text-accent-foreground"
+            : "bg-radix-amber-a-3 text-foreground"
+        )}
+      >
+        {votingStateLabel(entry, status)}
+      </span>
+      <span className="rounded-full bg-radix-purple-a-4 px-3 py-1 text-xs font-semibold text-foreground">
+        {entry.averageScore == null ? "Awaiting scores" : `${entry.averageScore} avg`}
+      </span>
+    </div>
+  );
+}
+
+function ChartView({
+  entries,
+  status,
+  viewer,
+  onSelectEntry,
+  onToggleEntryVoting,
+  pendingEntryId
+}: Omit<ResultsScoreboardTableProps, "entries"> & { entries: ScoreboardEntryView[] }) {
+  const maxScore = Math.max(...entries.map((entry) => entry.totalScore), 1);
+
+  return (
+    <div className="space-y-3" data-testid="scoreboard-chart-view">
+      <AnimatePresence initial={false}>
+        {entries.map((entry) => {
+          const width = Math.max((entry.totalScore / maxScore) * 100, entry.totalScore === 0 ? 8 : 14);
+
+          return (
+            <motion.div
+              layout
+              className="glass-panel flex cursor-pointer flex-col gap-4 rounded-[1.75rem] p-4 transition hover:bg-radix-teal-a-2 focus-within:bg-radix-teal-a-2 sm:p-5"
+              data-testid={`scoreboard-row-${entry.slug}`}
+              key={entry.id}
+              onClick={() => onSelectEntry(entry)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onSelectEntry(entry);
+                }
+              }}
+              role="button"
+              tabIndex={0}
+            >
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start gap-4">
+                    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-radix-teal-a-4 font-display text-sm font-black text-primary">
+                      {entry.rank}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-3">
+                        <div className="truncate font-semibold text-foreground">{entry.projectName}</div>
+                        <EntryMetaPills entry={entry} status={status} />
+                      </div>
+                      <div className="mt-1 text-sm text-muted-foreground">{entry.teamName ?? "Team name pending"}</div>
+                      {entry.summary ? (
+                        <div className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">{entry.summary}</div>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div className="mt-4">
+                    <div className="flex items-center justify-between gap-4 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      <span>Aggregate score</span>
+                      <span>{entry.totalScore}</span>
+                    </div>
+                    <div className="mt-2 h-4 overflow-hidden rounded-full bg-radix-gray-a-3">
+                      <motion.div
+                        animate={{ width: `${width}%` }}
+                        className={cn(
+                          "h-full rounded-full",
+                          entry.isVotingOpen
+                            ? "bg-[linear-gradient(90deg,var(--accent),rgba(72,229,254,0.45))]"
+                            : "bg-[linear-gradient(90deg,rgba(217,140,20,0.85),rgba(217,140,20,0.35))]"
+                        )}
+                        transition={{ duration: 0.35, ease: "easeOut" }}
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap gap-2 lg:max-w-[16rem] lg:justify-end">
+                  <ScoreboardActionButton
+                    entry={entry}
+                    onSelectEntry={onSelectEntry}
+                    status={status}
+                    viewer={viewer}
+                  />
+                  <ManagerVotingToggle
+                    entry={entry}
+                    onToggleEntryVoting={onToggleEntryVoting}
+                    pendingEntryId={pendingEntryId}
+                    status={status}
+                  />
+                </div>
+              </div>
+            </motion.div>
+          );
+        })}
+      </AnimatePresence>
+    </div>
+  );
 }
 
 export function ResultsScoreboardTable({
   entries,
   status,
   viewer,
-  onSelectEntry
+  onSelectEntry,
+  onToggleEntryVoting,
+  pendingEntryId
 }: ResultsScoreboardTableProps) {
+  const [viewMode, setViewMode] = React.useState<"table" | "chart">("table");
+  const showManagerControls = viewer.isManager;
+
   if (entries.length === 0) {
     return (
       <div className="glass-panel rounded-[2rem] border border-border/80 p-6 sm:p-8">
         <div className="eyebrow">Workbook-driven board</div>
-        <h3 className="mt-3 font-display text-2xl font-black text-foreground">No projects loaded yet</h3>
+        <h3 className="mt-3 font-display text-2xl font-black text-foreground" data-testid="scoreboard-empty-heading">
+          No projects loaded yet
+        </h3>
         <p className="mt-4 max-w-2xl text-sm leading-7 text-muted-foreground">
           This board fills with real judging data as soon as the manager uploads the XLSX workbook.
         </p>
@@ -56,171 +256,241 @@ export function ResultsScoreboardTable({
   }
 
   return (
-    <>
-      <div className="space-y-3 md:hidden">
-        <AnimatePresence initial={false}>
-          {entries.map((entry) => (
-            <motion.div
-              layout
-              className="glass-panel flex cursor-pointer flex-col gap-4 rounded-[1.7rem] p-4 text-left transition hover:bg-radix-teal-a-2 focus-within:bg-radix-teal-a-2"
-              data-testid={`scoreboard-row-${entry.slug}`}
-              key={entry.id}
-              onClick={() => onSelectEntry(entry)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" || event.key === " ") {
-                  event.preventDefault();
-                  onSelectEntry(entry);
-                }
-              }}
-              role="button"
-              tabIndex={0}
-            >
-              <div className="flex items-start gap-4">
-                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-radix-teal-a-4 font-display text-sm font-black text-primary">
-                  {entry.rank}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-radix-purple-a-4 font-display text-lg font-black text-foreground">
-                      {entry.projectName.slice(0, 1)}
-                    </div>
-                    <div className="min-w-0">
-                      <div className="truncate font-semibold text-foreground">{entry.projectName}</div>
-                      <div className="truncate text-sm text-muted-foreground">
-                        {entry.teamName ?? "Team name pending"}
-                      </div>
-                    </div>
-                  </div>
-                  {entry.summary ? (
-                    <div className="mt-3 line-clamp-2 text-xs leading-6 text-muted-foreground">{entry.summary}</div>
-                  ) : null}
-                </div>
-              </div>
-
-              <div className="flex flex-wrap gap-2">
-                <span className="rounded-full bg-radix-gray-a-3 px-3 py-1 text-xs font-semibold text-muted-foreground">
-                  {entry.voteCount} vote{entry.voteCount === 1 ? "" : "s"}
-                </span>
-                <span className="rounded-full bg-radix-teal-a-3 px-3 py-1 text-xs font-semibold text-accent-foreground">
-                  {entry.averageScore == null ? "Awaiting scores" : `${entry.averageScore} avg`}
-                </span>
-              </div>
-
-              <div className="flex items-center justify-between gap-4">
-                <div>
-                  <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                    Aggregate
-                  </div>
-                  <motion.div layout className="font-display text-3xl font-black text-foreground">
-                    {entry.totalScore}
-                  </motion.div>
-                </div>
-                  <Button
-                    className="min-w-[118px] justify-center"
-                    data-testid={`scoreboard-action-${entry.slug}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onSelectEntry(entry);
-                    }}
-                    size="sm"
-                    type="button"
-                    variant={entry.canVote ? "default" : "outline"}
-                  >
-                    {entry.canVote ? <Vote className="h-4 w-4" /> : <Lock className="h-4 w-4" />}
-                    {actionLabel({ entry, status, viewer })}
-                  </Button>
-              </div>
-            </motion.div>
-          ))}
-        </AnimatePresence>
-      </div>
-
-      <div className="hidden overflow-hidden rounded-[2rem] border border-border bg-radix-gray-a-2 md:block">
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[680px] border-separate border-spacing-0">
-            <thead>
-              <tr className="text-left">
-                {["Rank", "Project", "Votes", "Aggregate", "Action"].map((header) => (
-                  <th
-                    key={header}
-                    className="border-b border-border px-5 py-4 text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground"
-                  >
-                    {header}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <AnimatePresence initial={false}>
-              <motion.tbody layout>
-                {entries.map((entry) => (
-                  <motion.tr
-                    data-testid={`scoreboard-row-${entry.slug}`}
-                    layout
-                    key={entry.id}
-                    className="group cursor-pointer transition hover:bg-radix-teal-a-2 focus-within:bg-radix-teal-a-2"
-                    onClick={() => onSelectEntry(entry)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        onSelectEntry(entry);
-                      }
-                    }}
-                    tabIndex={0}
-                  >
-                    <td className="border-b border-border px-5 py-4">
-                      <div className="flex h-11 w-11 items-center justify-center rounded-full bg-radix-teal-a-4 font-display text-sm font-black text-primary">
-                        {entry.rank}
-                      </div>
-                    </td>
-                    <td className="border-b border-border px-5 py-4">
-                      <div className="flex items-center gap-4">
-                        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-radix-purple-a-4 font-display text-lg font-black text-foreground">
-                          {entry.projectName.slice(0, 1)}
-                        </div>
-                        <div>
-                          <div className="font-semibold text-foreground">{entry.projectName}</div>
-                          <div className="text-sm text-muted-foreground">
-                            {entry.teamName ?? "Team name pending"}
-                          </div>
-                          {entry.summary ? (
-                            <div className="mt-1 line-clamp-1 text-xs text-muted-foreground">{entry.summary}</div>
-                          ) : null}
-                        </div>
-                      </div>
-                    </td>
-                    <td className="border-b border-border px-5 py-4 text-sm text-muted-foreground">
-                      {entry.voteCount} vote{entry.voteCount === 1 ? "" : "s"}
-                    </td>
-                    <td className="border-b border-border px-5 py-4">
-                      <motion.div layout className="font-display text-2xl font-black text-foreground">
-                        {entry.totalScore}
-                        <span className="ml-2 text-sm font-medium text-muted-foreground">
-                          {entry.averageScore == null ? "No scores yet" : `${entry.averageScore} avg`}
-                        </span>
-                      </motion.div>
-                    </td>
-                    <td
-                      className="border-b border-border px-5 py-4"
-                      onClick={(event) => event.stopPropagation()}
-                    >
-                      <Button
-                        className="min-w-[118px] justify-center"
-                        data-testid={`scoreboard-action-${entry.slug}`}
-                        onClick={() => onSelectEntry(entry)}
-                        size="sm"
-                        variant={entry.canVote ? "default" : "outline"}
-                      >
-                        {entry.canVote ? <Vote className="h-4 w-4" /> : <Lock className="h-4 w-4" />}
-                        {actionLabel({ entry, status, viewer })}
-                      </Button>
-                    </td>
-                  </motion.tr>
-                ))}
-              </motion.tbody>
-            </AnimatePresence>
-          </table>
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 rounded-[1.7rem] border border-border/70 bg-radix-gray-a-2/65 p-3 sm:flex-row sm:items-center sm:justify-between sm:p-4">
+        <div className="min-w-0">
+          <div className="text-sm font-semibold text-foreground">Board view</div>
+          <div className="text-sm text-muted-foreground">
+            Switch between the ranked table and a horizontal bar chart without leaving the scoreboard.
+          </div>
+        </div>
+        <div className="inline-flex w-full rounded-full bg-radix-gray-a-3 p-1 sm:w-auto">
+          <button
+            className={cn(
+              "inline-flex flex-1 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition",
+              viewMode === "table" ? "bg-background text-foreground shadow-soft" : "text-muted-foreground"
+            )}
+            data-testid="scoreboard-view-table"
+            onClick={() => setViewMode("table")}
+            type="button"
+          >
+            <Table2 className="h-4 w-4" />
+            Table
+          </button>
+          <button
+            className={cn(
+              "inline-flex flex-1 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition",
+              viewMode === "chart" ? "bg-background text-foreground shadow-soft" : "text-muted-foreground"
+            )}
+            data-testid="scoreboard-view-chart"
+            onClick={() => setViewMode("chart")}
+            type="button"
+          >
+            <BarChart3 className="h-4 w-4" />
+            Bar chart
+          </button>
         </div>
       </div>
-    </>
+
+      {viewMode === "chart" ? (
+        <ChartView
+          entries={entries}
+          onSelectEntry={onSelectEntry}
+          onToggleEntryVoting={showManagerControls ? onToggleEntryVoting : undefined}
+          pendingEntryId={pendingEntryId}
+          status={status}
+          viewer={viewer}
+        />
+      ) : (
+        <>
+          <div className="space-y-3 md:hidden">
+            <AnimatePresence initial={false}>
+              {entries.map((entry) => (
+                <motion.div
+                  layout
+                  className="glass-panel flex cursor-pointer flex-col gap-4 rounded-[1.7rem] p-4 text-left transition hover:bg-radix-teal-a-2 focus-within:bg-radix-teal-a-2"
+                  data-testid={`scoreboard-row-${entry.slug}`}
+                  key={entry.id}
+                  onClick={() => onSelectEntry(entry)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      onSelectEntry(entry);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div className="flex items-start gap-4">
+                    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-radix-teal-a-4 font-display text-sm font-black text-primary">
+                      {entry.rank}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-radix-purple-a-4 font-display text-lg font-black text-foreground">
+                          {entry.projectName.slice(0, 1)}
+                        </div>
+                        <div className="min-w-0">
+                          <div className="truncate font-semibold text-foreground">{entry.projectName}</div>
+                          <div className="truncate text-sm text-muted-foreground">
+                            {entry.teamName ?? "Team name pending"}
+                          </div>
+                        </div>
+                      </div>
+                      {entry.summary ? (
+                        <div className="mt-3 line-clamp-2 text-xs leading-6 text-muted-foreground">{entry.summary}</div>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <EntryMetaPills entry={entry} status={status} />
+
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                        Aggregate
+                      </div>
+                      <motion.div layout className="font-display text-3xl font-black text-foreground">
+                        {entry.totalScore}
+                      </motion.div>
+                    </div>
+                    <ScoreboardActionButton
+                      entry={entry}
+                      onSelectEntry={onSelectEntry}
+                      status={status}
+                      viewer={viewer}
+                    />
+                  </div>
+
+                  {showManagerControls ? (
+                    <div className="flex justify-end">
+                      <ManagerVotingToggle
+                        entry={entry}
+                        onToggleEntryVoting={onToggleEntryVoting}
+                        pendingEntryId={pendingEntryId}
+                        status={status}
+                      />
+                    </div>
+                  ) : null}
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </div>
+
+          <div
+            className="hidden overflow-hidden rounded-[2rem] border border-border bg-radix-gray-a-2 md:block"
+            data-testid="scoreboard-table-view"
+          >
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[760px] border-separate border-spacing-0">
+                <thead>
+                  <tr className="text-left">
+                    {["Rank", "Project", "Votes", "Aggregate", "Status", "Action"]
+                      .concat(showManagerControls ? ["Manager"] : [])
+                      .map((header) => (
+                        <th
+                          key={header}
+                          className="border-b border-border px-5 py-4 text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground"
+                        >
+                          {header}
+                        </th>
+                      ))}
+                  </tr>
+                </thead>
+                <AnimatePresence initial={false}>
+                  <motion.tbody layout>
+                    {entries.map((entry) => (
+                      <motion.tr
+                        data-testid={`scoreboard-row-${entry.slug}`}
+                        layout
+                        key={entry.id}
+                        className="group cursor-pointer transition hover:bg-radix-teal-a-2 focus-within:bg-radix-teal-a-2"
+                        onClick={() => onSelectEntry(entry)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            onSelectEntry(entry);
+                          }
+                        }}
+                        tabIndex={0}
+                      >
+                        <td className="border-b border-border px-5 py-4">
+                          <div className="flex h-11 w-11 items-center justify-center rounded-full bg-radix-teal-a-4 font-display text-sm font-black text-primary">
+                            {entry.rank}
+                          </div>
+                        </td>
+                        <td className="border-b border-border px-5 py-4">
+                          <div className="flex items-center gap-4">
+                            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-radix-purple-a-4 font-display text-lg font-black text-foreground">
+                              {entry.projectName.slice(0, 1)}
+                            </div>
+                            <div className="min-w-0">
+                              <div className="font-semibold text-foreground">{entry.projectName}</div>
+                              <div className="text-sm text-muted-foreground">
+                                {entry.teamName ?? "Team name pending"}
+                              </div>
+                              {entry.summary ? (
+                                <div className="mt-1 line-clamp-1 text-xs text-muted-foreground">{entry.summary}</div>
+                              ) : null}
+                            </div>
+                          </div>
+                        </td>
+                        <td className="border-b border-border px-5 py-4 text-sm text-muted-foreground">
+                          {entry.voteCount} vote{entry.voteCount === 1 ? "" : "s"}
+                        </td>
+                        <td className="border-b border-border px-5 py-4">
+                          <motion.div layout className="font-display text-2xl font-black text-foreground">
+                            {entry.totalScore}
+                            <span className="ml-2 text-sm font-medium text-muted-foreground">
+                              {entry.averageScore == null ? "No scores yet" : `${entry.averageScore} avg`}
+                            </span>
+                          </motion.div>
+                        </td>
+                        <td className="border-b border-border px-5 py-4">
+                          <span
+                            className={cn(
+                              "inline-flex rounded-full px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em]",
+                              entry.isVotingOpen
+                                ? "bg-radix-teal-a-3 text-accent-foreground"
+                                : "bg-radix-amber-a-3 text-foreground"
+                            )}
+                          >
+                            {votingStateLabel(entry, status)}
+                          </span>
+                        </td>
+                        <td
+                          className="border-b border-border px-5 py-4"
+                          onClick={(event) => event.stopPropagation()}
+                        >
+                          <ScoreboardActionButton
+                            entry={entry}
+                            onSelectEntry={onSelectEntry}
+                            status={status}
+                            viewer={viewer}
+                          />
+                        </td>
+                        {showManagerControls ? (
+                          <td
+                            className="border-b border-border px-5 py-4"
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            <ManagerVotingToggle
+                              entry={entry}
+                              onToggleEntryVoting={onToggleEntryVoting}
+                              pendingEntryId={pendingEntryId}
+                              status={status}
+                            />
+                          </td>
+                        ) : null}
+                      </motion.tr>
+                    ))}
+                  </motion.tbody>
+                </AnimatePresence>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
   );
 }

--- a/components/vote-dialog.tsx
+++ b/components/vote-dialog.tsx
@@ -112,6 +112,7 @@ export function VoteDialog({
   const needsAuth = !viewer.isAuthenticated;
   const isBlocked = entry.isSelfVoteBlocked;
   const hasRecordedVote = entry.currentUserVote != null;
+  const isEntryClosed = !entry.isVotingOpen;
   const previewScore = Number(selectedScore || String(entry.currentUserVote ?? 7));
   const preview = describeScore(previewScore);
   const recordedVote = entry.currentUserVote == null ? null : describeScore(entry.currentUserVote);
@@ -207,6 +208,12 @@ export function VoteDialog({
                 </div>
               ) : null}
 
+              {isEntryClosed && !hasRecordedVote && status === "OPEN" ? (
+                <div className="rounded-[1.6rem] border border-[rgb(217_140_20_/_0.28)] bg-[rgb(217_140_20_/_0.08)] p-5 text-sm leading-7 text-foreground">
+                  Voting is paused for this project right now. The manager can reopen it from the scoreboard at any time.
+                </div>
+              ) : null}
+
               {errorMessage ? (
                 <div
                   aria-live="polite"
@@ -237,23 +244,6 @@ export function VoteDialog({
                       : "Finalized results are locked now. Thanks for helping judge the field."}
                   </p>
                 </div>
-              ) : needsAuth ? (
-                <div className="glass-panel flex flex-1 flex-col justify-between rounded-[1.9rem] p-6 sm:p-7">
-                  <JudgeAuthPanel
-                    afterAuthenticate={() => {
-                      onVoteSaved();
-                    }}
-                    description="The board stays public, but signing in unlocks a single decisive score per project. Once you submit, that score is locked for the round."
-                    title="Sign in to cast your vote"
-                  />
-                </div>
-              ) : isBlocked ? (
-                <div className="glass-panel flex flex-1 flex-col justify-center rounded-[1.9rem] p-6 sm:p-7">
-                  <h3 className="font-display text-3xl font-black">You can’t score this one</h3>
-                  <p className="mt-4 max-w-md text-sm leading-7 text-muted-foreground">
-                    We block self-voting automatically so judges never need to second-guess whether a score is allowed.
-                  </p>
-                </div>
               ) : hasRecordedVote ? (
                 <div className="glass-panel flex flex-1 flex-col justify-between rounded-[1.9rem] p-6 sm:p-7">
                   <div>
@@ -279,6 +269,30 @@ export function VoteDialog({
                       </div>
                     </div>
                   </div>
+                </div>
+              ) : isEntryClosed ? (
+                <div className="glass-panel flex flex-1 flex-col justify-center rounded-[1.9rem] p-6 sm:p-7">
+                  <h3 className="font-display text-3xl font-black">Voting is paused</h3>
+                  <p className="mt-4 max-w-md text-sm leading-7 text-muted-foreground">
+                    This project is still visible on the public board, but the manager has closed it to new votes for now.
+                  </p>
+                </div>
+              ) : needsAuth ? (
+                <div className="glass-panel flex flex-1 flex-col justify-between rounded-[1.9rem] p-6 sm:p-7">
+                  <JudgeAuthPanel
+                    afterAuthenticate={() => {
+                      onVoteSaved();
+                    }}
+                    description="The board stays public, but signing in unlocks a single decisive score per project. Once you submit, that score is locked for the round."
+                    title="Sign in to cast your vote"
+                  />
+                </div>
+              ) : isBlocked ? (
+                <div className="glass-panel flex flex-1 flex-col justify-center rounded-[1.9rem] p-6 sm:p-7">
+                  <h3 className="font-display text-3xl font-black">You can’t score this one</h3>
+                  <p className="mt-4 max-w-md text-sm leading-7 text-muted-foreground">
+                    We block self-voting automatically so judges never need to second-guess whether a score is allowed.
+                  </p>
                 </div>
               ) : (
                 <div className="glass-panel flex flex-1 flex-col rounded-[1.9rem] p-5">

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -6,6 +6,7 @@ The app is intentionally a single-screen product.
 
 - Public users land on `/` and can always see the live scoreboard.
 - The manager uses the same screen to download the XLSX template, upload entries, begin voting, finalize results, and export the final workbook.
+- The manager also uses the same scoreboard to close or reopen individual projects for new voting.
 - Judges use the same screen to sign in and vote from the modal.
 - Legacy routes such as `/projects`, `/results`, and `/submission/assets` redirect back to `/`.
 
@@ -104,6 +105,7 @@ Every uploaded team-member email is stored against that project.
 
 - The manager clicks `Begin voting`.
 - Authenticated judges can vote.
+- The manager can pause voting on a specific project without removing it from the public board.
 - Public viewers can keep watching the board update live.
 - Active tabs refresh automatically every 5 seconds during judging, and inactive tabs refresh again when they regain focus.
 
@@ -120,7 +122,8 @@ The progress model is intentionally practical for hackathon use.
 
 - A judge joins the denominator when they cast their first vote.
 - Projects a judge is self-vote-blocked from are removed from that judge's denominator.
-- Completion means every participating judge has scored every project they are eligible to judge.
+- Projects the manager has closed to new votes are also removed from the live denominator until reopened.
+- Completion means every participating judge has scored every project that is still open and eligible for them.
 
 This keeps the progress bar coherent without introducing heavy judge-roster administration.
 
@@ -142,12 +145,13 @@ See [/Users/rajeev/Code/hackathon-voting-prototype/prisma/schema.prisma](/Users/
 3. Fill one row per project and keep project names unique.
 4. Upload the XLSX from the manager panel.
 5. Confirm all entries appear on the scoreboard and that there is no placeholder content.
-6. If you need a clean rehearsal, click `Reset dry run`, then upload again.
-7. Click `Begin voting` once the judges are ready.
-8. Ask judges to sign in once and vote from the modal.
-9. Watch the progress card until completion reaches `100%`.
-10. Click `Finalize`.
-11. Export the finalized workbook.
+6. If a project should stay visible but stop taking new votes, use its row-level open / close control on the board.
+7. If you need a clean rehearsal, click `Reset dry run`, then upload again.
+8. Click `Begin voting` once the judges are ready.
+9. Ask judges to sign in once and vote from the modal.
+10. Watch the progress card until completion reaches `100%`.
+11. Click `Finalize`.
+12. Export the finalized workbook.
 
 ## Proof and verification
 

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -54,6 +54,7 @@ Prisma models live in [schema.prisma](/Users/rajeev/Code/hackathon-voting-protot
   - team name
   - summary
   - metadata JSON for tolerated extra workbook columns
+  - per-entry `isVotingOpen` state for manager row controls
 
 ### `EntryTeamEmail`
 
@@ -63,7 +64,7 @@ Prisma models live in [schema.prisma](/Users/rajeev/Code/hackathon-voting-protot
 ### `Vote`
 
 - One active row per `entryId + judgeEmail`
-- Re-submitting a score updates the existing row instead of creating duplicates
+- Re-submitting a score is rejected; each judge gets one locked score per project for the round
 
 ## Workbook contract
 
@@ -106,12 +107,14 @@ Self-vote blocking is derived from normalized email equality between the signed-
 
 - Public scoreboard is visible.
 - Manager can download the template and upload a workbook.
+- Manager can close or reopen individual projects before the round starts.
 - Voting actions open the modal but remain locked.
 
 ### `OPEN`
 
 - Public scoreboard stays visible.
 - Authenticated judges can vote.
+- The manager can close or reopen individual projects without removing them from the public board.
 - A judge becomes part of the progress denominator the moment they cast their first score.
 - Each judge can submit exactly one score per project for the active round.
 - After submission, that project is locked for that judge unless the manager resets the whole round.
@@ -132,7 +135,8 @@ Completion is intentionally simple and operationally practical:
 - A judge joins the round once they cast their first score.
 - For each participating judge, the app computes which entries they are eligible to score.
 - Entries blocked by self-vote rules are removed from that judge's denominator.
-- The round is complete when every participating judge has scored every project they are eligible to judge.
+- Entries the manager has closed to new votes are removed from the live denominator until reopened.
+- The round is complete when every participating judge has scored every project that is still open and eligible for them.
 - Finalization is available only when the round is `OPEN` and that completion rule is satisfied.
 
 This keeps the rule coherent without introducing a separate roster-management system.
@@ -149,6 +153,8 @@ This keeps the rule coherent without introducing a separate roster-management sy
 
 - The design system preserves the existing dark teal / glass / results-dashboard visual language.
 - Light mode is supported and intentionally styled instead of falling back to generic defaults.
+- The main screen is intentionally one column on every viewport so the scoreboard owns the page and progress sits below it.
+- The scoreboard can switch between a ranked table and a horizontal bar chart.
 - The vote modal is the emotional center of the product and is designed to:
   - keep project context visible
   - support keyboard-first scoring

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -25,7 +25,9 @@ Flows proven:
 - Anonymous user can view the scoreboard but not manager controls
 - Manager downloads the XLSX template
 - Manager uploads a workbook and workbook-driven entries appear
+- Manager switches the scoreboard between table and horizontal bar-chart views
 - Manager begins voting
+- Manager closes and reopens an individual project for new voting
 - Judge signs in with email-code auth
 - The mobile email-code auth flow survives a page remount and returns to the verification step instead of resetting to email entry
 - Vote modal supports keyboard selection and submission
@@ -36,6 +38,7 @@ Flows proven:
 - Manager downloads the finalized XLSX export
 - Public finalized state is visible and modal voting is locked
 - The judging-progress state card keeps its label fully contained at mobile and wide desktop widths
+- The scoreboard remains visually ahead of the progress section, and the progress section stays below the board across breakpoints
 
 Artifacts:
 
@@ -53,7 +56,7 @@ Date: `2026-03-24`
 
 Goal:
 
-- Re-check the judging-progress header after the mobile state-card clipping report
+- Re-check the single-column ordering after removing the old side rail and ensure progress stays below the scoreboard cleanly
 
 Local production surface:
 
@@ -73,8 +76,8 @@ Focused proof artifacts:
 Observed result:
 
 - The state card now renders `Preparing` instead of the raw uppercase enum token.
-- Mobile at `430px` keeps the three progress cards readable without clipping or overlap.
-- Wide desktop at `1575px` keeps the right-hand progress rail balanced and free of dead space.
+- Mobile at `430px` keeps the progress cards readable without clipping or overlap.
+- Wide desktop at `1575px` keeps the scoreboard dominant instead of splitting attention with a side rail.
 - DOM measurement on both local production and the live site confirmed the state label stayed inset inside its card with healthy top and bottom space.
 
 Result:
@@ -87,7 +90,7 @@ Date: `2026-03-24`
 
 Goal:
 
-- Prove the judging-progress cards stay contained at the in-between widths where the live site previously clipped
+- Prove the single-column scoreboard keeps the board above the progress section and stays contained at the in-between widths where the live site previously clipped
 
 Local validation:
 
@@ -105,9 +108,10 @@ Viewports covered:
 Proof contract:
 
 - No horizontal page overflow
+- Progress panel appears below the scoreboard section
 - State card remains inside the viewport
 - State label keeps healthy top and bottom inset inside the card
-- Mid-width layouts use a two-up row with a full-width state card instead of forcing three narrow columns
+- Mid-width layouts keep the one-column reading order without accidental side-by-side competition
 
 Artifacts:
 
@@ -129,7 +133,7 @@ Date: `2026-03-24`
 
 Goal:
 
-- Rebalance the screen so the scoreboard and next action dominate above the fold instead of a large explanatory hero
+- Rebalance the screen so the scoreboard and next action dominate above the fold instead of a large explanatory hero or side rail
 
 Guidance used:
 
@@ -151,7 +155,7 @@ Observed local result:
 
 - Wide desktop no longer burns most of the first screen on a tall empty hero.
 - The scoreboard header and first rows now appear in the primary scan area instead of being pushed too far down.
-- Mid-width and mobile now carry only the decision-driving summary above the fold, with the board appearing sooner.
+- Mid-width and mobile now carry only the decision-driving summary above the fold, with the board appearing sooner and progress staying below it.
 - Supporting rules remain present but visually secondary.
 
 Artifacts:
@@ -175,7 +179,7 @@ LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test t
 Observed production result:
 
 - Wide desktop keeps the scoreboard and first action in the dominant scan path without the old dead-zone hero feeling.
-- Mid-width and mobile preserve the same reading order and expose the scoreboard sooner.
+- Mid-width and mobile preserve the same reading order, expose the scoreboard sooner, and keep progress below the board.
 - The focused breakpoint proof passed on the live app across the intentional desktop, tablet, mid-width, and mobile combinations.
 
 Production artifacts:
@@ -232,7 +236,8 @@ Viewports exercised:
 Behavior proof:
 
 - Public scoreboard is reachable without auth
-- Manager template download, workbook upload, begin-voting, finalization, and export all complete successfully
+- Manager template download, workbook upload, begin-voting, per-entry close / reopen, finalization, and export all complete successfully
+- Scoreboard table and horizontal bar-chart modes both render correctly
 - The vote modal opens from the scoreboard, accepts keyboard score selection, submits successfully, and then locks the judge out from changing that project
 - Self-vote blocking is enforced from uploaded team emails
 - Finalized public state locks the modal and keeps the scoreboard readable

--- a/lib/competition-logic.ts
+++ b/lib/competition-logic.ts
@@ -7,6 +7,7 @@ export type EntryRecordForLogic = {
   projectName: string;
   teamName: string | null;
   summary: string | null;
+  isVotingOpen: boolean;
   teamEmails: { email: string }[];
   votes: {
     judgeEmail: string;
@@ -34,6 +35,7 @@ export type ScoreboardEntryView = {
   voteCount: number;
   teamEmails: string[];
   judgeEmails: string[];
+  isVotingOpen: boolean;
   isSelfVoteBlocked: boolean;
   currentUserVote: number | null;
   canVote: boolean;
@@ -46,6 +48,7 @@ export type ProgressSummary = {
   expectedVotes: number;
   participatingJudgeCount: number;
   entryCount: number;
+  openEntryCount: number;
   isComplete: boolean;
   helperText: string;
 };
@@ -85,10 +88,14 @@ export function deriveProgress({
   entries
 }: {
   status: VotingStatus;
-  entries: Pick<EntryRecordForLogic, "teamEmails" | "votes">[];
+  entries: Pick<EntryRecordForLogic, "teamEmails" | "votes" | "isVotingOpen">[];
 }): ProgressSummary {
   const entryCount = entries.length;
+  const openEntries = entries.filter((entry) => entry.isVotingOpen);
+  const openEntryCount = openEntries.length;
   const votes = entries.flatMap((entry) => entry.votes);
+  const openVotes = openEntries.flatMap((entry) => entry.votes);
+  const hasAnyVotes = votes.length > 0;
 
   if (!entryCount) {
     return {
@@ -97,6 +104,7 @@ export function deriveProgress({
       expectedVotes: 0,
       participatingJudgeCount: 0,
       entryCount: 0,
+      openEntryCount: 0,
       isComplete: false,
       helperText: "Upload a workbook to populate the public scoreboard."
     };
@@ -106,21 +114,40 @@ export function deriveProgress({
     return {
       percentage: 0,
       castVotes: 0,
-      expectedVotes: entryCount,
+      expectedVotes: openEntryCount,
       participatingJudgeCount: 0,
       entryCount,
+      openEntryCount,
       isComplete: false,
-      helperText: "Voting has not started yet. The manager can review the upload and begin judging when ready."
+      helperText:
+        openEntryCount > 0
+          ? "Voting has not started yet. The manager can review the upload, close any project that should stay out of the round, and begin judging when ready."
+          : "Every project is currently closed to new votes. Reopen at least one entry before judging starts."
+    };
+  }
+
+  if (openEntryCount === 0) {
+    return {
+      percentage: hasAnyVotes ? 100 : 0,
+      castVotes: 0,
+      expectedVotes: 0,
+      participatingJudgeCount: 0,
+      entryCount,
+      openEntryCount,
+      isComplete: hasAnyVotes,
+      helperText: hasAnyVotes
+        ? "No projects are currently open for new votes. Reopen an entry to keep judging, or finalize if the round is done."
+        : "No projects are currently open for voting. Reopen at least one entry to let judges score."
     };
   }
 
   const participatingJudgeEmails = Array.from(
-    new Set(votes.map((vote) => normalizeEmail(vote.judgeEmail)))
+    new Set(openVotes.map((vote) => normalizeEmail(vote.judgeEmail)))
   );
   const participatingJudgeCount = participatingJudgeEmails.length;
-  const castVotes = votes.length;
+  const castVotes = openVotes.length;
   const expectedVotes = participatingJudgeEmails.reduce((sum, judgeEmail) => {
-    const eligibleEntryCount = entries.filter(
+    const eligibleEntryCount = openEntries.filter(
       (entry) => !isSelfVoteBlocked(entry.teamEmails.map((teamMember) => teamMember.email), judgeEmail)
     ).length;
 
@@ -130,7 +157,7 @@ export function deriveProgress({
   const isComplete =
     expectedVotes > 0 &&
     participatingJudgeEmails.every((judgeEmail) =>
-      entries.every((entry) => {
+      openEntries.every((entry) => {
         const entryEmails = entry.teamEmails.map((teamMember) => teamMember.email);
         if (isSelfVoteBlocked(entryEmails, judgeEmail)) {
           return true;
@@ -143,10 +170,11 @@ export function deriveProgress({
   if (status === "FINALIZED") {
     return {
       percentage: 100,
-      castVotes,
+      castVotes: votes.length,
       expectedVotes,
       participatingJudgeCount,
       entryCount,
+      openEntryCount,
       isComplete: true,
       helperText: "Judging is finalized. Public scores are locked and export is available to the manager."
     };
@@ -156,12 +184,13 @@ export function deriveProgress({
     return {
       percentage: 0,
       castVotes,
-      expectedVotes: entryCount,
+      expectedVotes: openEntryCount,
       participatingJudgeCount: 0,
       entryCount,
+      openEntryCount,
       isComplete: false,
       helperText:
-        "Voting is open. Judges join the completion count when they cast their first score, and completion means every participating judge has scored every project they are eligible to judge."
+        "Voting is open. Judges join the completion count when they cast their first score, and completion means every participating judge has covered every project that is still open for them."
     };
   }
 
@@ -171,10 +200,11 @@ export function deriveProgress({
     expectedVotes,
     participatingJudgeCount,
     entryCount,
+    openEntryCount,
     isComplete,
     helperText: isComplete
-      ? "Every participating judge has scored every project they are eligible to judge. The manager can finalize the results."
-      : "Completion is measured as every participating judge covering every project they are eligible to judge. Self-vote exclusions are removed from the denominator automatically."
+      ? "Every participating judge has scored every project that is still open for them. The manager can finalize the results."
+      : "Completion is measured across projects that are still open for voting. Closed projects stay on the board but drop out of the denominator automatically."
   };
 }
 
@@ -213,6 +243,7 @@ export function deriveCompetitionSnapshot({
         averageScore: voteCount > 0 ? Number((totalScore / voteCount).toFixed(2)) : null,
         teamEmails,
         judgeEmails: Array.from(new Set(entry.votes.map((vote) => normalizeEmail(vote.judgeEmail)))),
+        isVotingOpen: entry.isVotingOpen,
         isSelfVoteBlocked: isSelfVoteBlocked(teamEmails, viewer.email),
         currentUserVote,
         lastVoteAt: entry.votes
@@ -233,6 +264,7 @@ export function deriveCompetitionSnapshot({
       rank: index + 1,
       canVote:
         status === "OPEN" &&
+        entry.isVotingOpen &&
         viewer.isAuthenticated &&
         !entry.isSelfVoteBlocked &&
         entry.currentUserVote == null &&
@@ -249,7 +281,7 @@ export function deriveCompetitionSnapshot({
     progress,
     canDownloadTemplate: viewer.isManager,
     canUploadSheet: viewer.isManager && status === "PREPARING",
-    canBeginVoting: viewer.isManager && status === "PREPARING" && entries.length > 0,
+    canBeginVoting: viewer.isManager && status === "PREPARING" && entries.some((entry) => entry.isVotingOpen),
     canFinalize: viewer.isManager && status === "OPEN" && progress.isComplete,
     canResetRound: viewer.isManager && (entries.length > 0 || status !== "PREPARING"),
     canDownloadFinalizedExport: viewer.isManager && status === "FINALIZED"

--- a/lib/competition.ts
+++ b/lib/competition.ts
@@ -157,6 +157,7 @@ export async function replaceEntriesFromWorkbook(buffer: ArrayBuffer | Buffer) {
           projectName: row.projectName,
           teamName: row.teamName,
           summary: row.summary,
+          isVotingOpen: true,
           metadata: Object.keys(row.metadata).length ? row.metadata : Prisma.JsonNull,
           teamEmails: {
             create: row.teamEmails.map((email) => ({
@@ -195,6 +196,17 @@ export async function beginVotingRound() {
   const entryCount = await withPrismaRetry(() => prisma.entry.count());
   if (entryCount === 0) {
     throw new Error("Upload at least one entry before opening voting.");
+  }
+
+  const openEntryCount = await withPrismaRetry(() =>
+    prisma.entry.count({
+      where: {
+        isVotingOpen: true
+      }
+    })
+  );
+  if (openEntryCount === 0) {
+    throw new Error("Reopen at least one project before beginning voting.");
   }
 
   await withPrismaRetry(() =>
@@ -268,6 +280,10 @@ export async function submitJudgeVote({
     throw new Error("That project could not be found.");
   }
 
+  if (!entry.isVotingOpen) {
+    throw new Error("Voting is currently closed for this project.");
+  }
+
   const normalizedJudgeEmail = normalizeEmail(judgeEmail);
   const isBlocked = entry.teamEmails.some(
     (teamMember) => normalizeEmail(teamMember.email) === normalizedJudgeEmail
@@ -298,6 +314,59 @@ export async function submitJudgeVote({
 
     throw error;
   }
+
+  safeRevalidateHome();
+}
+
+export async function setEntryVotingAvailability({
+  entryId,
+  isVotingOpen
+}: {
+  entryId: string;
+  isVotingOpen: boolean;
+}) {
+  const state = await ensureCompetitionState();
+  if (state.votingStatus === "FINALIZED") {
+    throw new Error("Entries cannot be reopened or closed after finalization.");
+  }
+
+  const entry = await withPrismaRetry(() =>
+    prisma.entry.findUnique({
+      where: { id: entryId }
+    })
+  );
+
+  if (!entry) {
+    throw new Error("That project could not be found.");
+  }
+
+  if (entry.isVotingOpen === isVotingOpen) {
+    return;
+  }
+
+  if (state.votingStatus === "PREPARING" && !isVotingOpen) {
+    const otherOpenEntries = await withPrismaRetry(() =>
+      prisma.entry.count({
+        where: {
+          isVotingOpen: true,
+          id: {
+            not: entryId
+          }
+        }
+      })
+    );
+
+    if (otherOpenEntries === 0) {
+      throw new Error("Keep at least one project open before judging starts.");
+    }
+  }
+
+  await withPrismaRetry(() =>
+    prisma.entry.update({
+      where: { id: entryId },
+      data: { isVotingOpen }
+    })
+  );
 
   safeRevalidateHome();
 }

--- a/prisma/migrations/20260324110000_add_entry_voting_open/migration.sql
+++ b/prisma/migrations/20260324110000_add_entry_voting_open/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Entry"
+ADD COLUMN "isVotingOpen" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Entry {
   teamName      String?
   summary       String?
   metadata      Json?
+  isVotingOpen  Boolean          @default(true)
   createdAt     DateTime         @default(now())
   updatedAt     DateTime         @updatedAt
   teamEmails    EntryTeamEmail[]

--- a/tests/competition-logic.test.ts
+++ b/tests/competition-logic.test.ts
@@ -22,6 +22,7 @@ describe("competition logic", () => {
           projectName: "Aurora Atlas",
           teamName: "Team North Star",
           summary: "Summary",
+          isVotingOpen: true,
           teamEmails: [{ email: "founder@example.com" }],
           votes: [
             { judgeEmail: "judge.one@example.com", score: 9, updatedAt: new Date("2026-03-23T12:00:00.000Z") },
@@ -34,6 +35,7 @@ describe("competition logic", () => {
           projectName: "Signal Bloom",
           teamName: "Team Bloom",
           summary: "Summary",
+          isVotingOpen: true,
           teamEmails: [{ email: "judge.one@example.com" }],
           votes: [
             { judgeEmail: "judge.two@example.com", score: 10, updatedAt: new Date("2026-03-23T12:03:00.000Z") }
@@ -68,6 +70,7 @@ describe("competition logic", () => {
           projectName: "Aurora Atlas",
           teamName: "Team North Star",
           summary: "Summary",
+          isVotingOpen: true,
           teamEmails: [{ email: "founder@example.com" }],
           votes: [{ judgeEmail: "judge.three@example.com", score: 9, updatedAt: new Date("2026-03-23T12:00:00.000Z") }]
         },
@@ -77,6 +80,7 @@ describe("competition logic", () => {
           projectName: "Signal Bloom",
           teamName: "Team Bloom",
           summary: "Summary",
+          isVotingOpen: true,
           teamEmails: [{ email: "builder@example.com" }],
           votes: []
         }
@@ -86,6 +90,47 @@ describe("competition logic", () => {
     expect(snapshot.progress.isComplete).toBe(false);
     expect(snapshot.canFinalize).toBe(false);
     expect(snapshot.progress.percentage).toBe(50);
+  });
+
+  it("excludes manager-closed projects from the live completion denominator", () => {
+    const snapshot = deriveCompetitionSnapshot({
+      status: "OPEN",
+      startedAt: new Date("2026-03-23T12:00:00.000Z"),
+      finalizedAt: null,
+      viewer: {
+        clerkUserId: "user_456",
+        email: "judge.three@example.com",
+        isAuthenticated: true,
+        isManager: false
+      },
+      entries: [
+        {
+          id: "entry-1",
+          slug: "aurora-atlas",
+          projectName: "Aurora Atlas",
+          teamName: "Team North Star",
+          summary: "Summary",
+          isVotingOpen: true,
+          teamEmails: [{ email: "founder@example.com" }],
+          votes: [{ judgeEmail: "judge.three@example.com", score: 9, updatedAt: new Date("2026-03-23T12:00:00.000Z") }]
+        },
+        {
+          id: "entry-2",
+          slug: "signal-bloom",
+          projectName: "Signal Bloom",
+          teamName: "Team Bloom",
+          summary: "Summary",
+          isVotingOpen: false,
+          teamEmails: [{ email: "builder@example.com" }],
+          votes: []
+        }
+      ]
+    });
+
+    expect(snapshot.progress.openEntryCount).toBe(1);
+    expect(snapshot.progress.isComplete).toBe(true);
+    expect(snapshot.progress.percentage).toBe(100);
+    expect(snapshot.entries.find((entry) => entry.id === "entry-2")?.canVote).toBe(false);
   });
 
   it("recognizes the exact manager email", () => {

--- a/tests/e2e/scoreboard-breakpoints.spec.ts
+++ b/tests/e2e/scoreboard-breakpoints.spec.ts
@@ -8,11 +8,11 @@ const viewports = [
   { name: "wide-desktop", width: 1575, height: 1100, colorScheme: "light" as const }
 ];
 
-test.describe("scoreboard progress rail stays coherent across breakpoints", () => {
+test.describe("single-column scoreboard stays coherent across breakpoints", () => {
   test.skip(!runLayoutProof, "Run this focused breakpoint proof only when explicitly requested.");
 
   for (const viewport of viewports) {
-    test(`${viewport.name} keeps the progress cards contained`, async ({ page }, testInfo) => {
+    test(`${viewport.name} keeps the scoreboard and progress flow coherent`, async ({ page }, testInfo) => {
       if (testInfo.project.name === "desktop-light" && viewport.name === "mobile-tight") {
         test.skip(true, "Mobile-tight layout is covered by the dedicated mobile project.");
       }
@@ -41,15 +41,15 @@ test.describe("scoreboard progress rail stays coherent across breakpoints", () =
 
       expect(pageMetrics.scrollWidth).toBe(pageMetrics.viewportWidth);
 
-      const summaryTop = await page.locator("[data-testid='workflow-summary']").evaluate((element) => {
-        return element.getBoundingClientRect().top;
-      });
       const scoreboardTop = await page.locator("[data-testid='scoreboard-section']").evaluate((element) => {
         return element.getBoundingClientRect().top;
       });
+      const progressTop = await page.locator("[data-testid='progress-panel']").evaluate((element) => {
+        return element.getBoundingClientRect().top;
+      });
 
-      expect(summaryTop).toBeGreaterThanOrEqual(0);
       expect(scoreboardTop).toBeLessThan(viewport.height * 0.82);
+      expect(progressTop).toBeGreaterThan(scoreboardTop);
 
       const stateMetrics = await page.locator("[data-testid='progress-stat-state']").evaluate((element) => {
         const rect = element.getBoundingClientRect();

--- a/tests/e2e/single-screen-voting.spec.ts
+++ b/tests/e2e/single-screen-voting.spec.ts
@@ -262,7 +262,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
   await test.step("Anonymous visitors can see the board but not manager tools", async () => {
     await anonymousPage.goto("/");
     await expect(anonymousPage.getByRole("heading", { name: "Live hackathon scoreboard" })).toBeVisible();
-    await expect(anonymousPage.getByText("No projects loaded yet")).toBeVisible();
+    await expect(anonymousPage.getByTestId("scoreboard-empty-heading")).toBeVisible();
     await expectProgressStateCardToContainValue(anonymousPage, "Preparing");
     await expect(anonymousPage.getByTestId("manager-download-template")).toHaveCount(0);
     await expect(anonymousPage.getByTestId("manager-upload-dropzone")).toHaveCount(0);
@@ -294,14 +294,40 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await expect(managerPage.getByTestId("scoreboard-row-harbor-pulse").nth(rowIndex)).toContainText(
       "Harbor Collective Reloaded"
     );
+
+    await managerPage.getByTestId("scoreboard-view-chart").click();
+    await expect(managerPage.getByTestId("scoreboard-chart-view")).toBeVisible();
+    await takeShot(managerPage, testInfo.outputPath("manager-chart-view.png"));
+    await managerPage.getByTestId("scoreboard-view-table").click();
+    if (testInfo.project.name.includes("mobile")) {
+      await expect(managerPage.getByTestId("scoreboard-row-aurora-atlas").nth(rowIndex)).toBeVisible();
+    } else {
+      await expect(managerPage.getByTestId("scoreboard-table-view")).toBeVisible();
+    }
     await takeShot(managerPage, testInfo.outputPath("manager-after-upload.png"));
 
     await managerPage.getByTestId("manager-begin-voting").click();
-    await expect(managerPage.getByTestId("workflow-summary").getByText("Judging live")).toBeVisible();
+    await expect(managerPage.getByTestId("progress-stat-state-value")).toHaveText("Voting live");
+
+    await managerPage
+      .getByTestId("manager-entry-toggle-harbor-pulse")
+      .nth(activeResponsiveIndex(testInfo.project.name))
+      .click();
+    await expect(managerPage.getByText("Harbor Pulse is now closed to new votes.")).toBeVisible();
+    await expect(
+      managerPage
+        .getByTestId("scoreboard-action-harbor-pulse")
+        .nth(activeResponsiveIndex(testInfo.project.name))
+    ).toContainText("Closed");
   });
 
   await test.step("Anonymous users stay read-only after voting opens", async () => {
     await anonymousPage.goto("/");
+    await openVoteDialog(anonymousPage, "Harbor Pulse");
+    await expect(anonymousPage.getByText("Voting is paused for this project right now.")).toBeVisible();
+    await expect(anonymousPage.getByTestId("submit-vote")).toHaveCount(0);
+    await anonymousPage.getByRole("button", { name: "Close" }).click();
+
     await openVoteDialog(anonymousPage, "Aurora Atlas");
     await expect(anonymousPage.getByText("Sign in to cast your vote")).toBeVisible();
     await expect(anonymousPage.getByTestId("submit-vote")).toHaveCount(0);
@@ -314,6 +340,10 @@ test("manager, judges, and public users complete the single-screen voting flow",
     } else {
       await signInJudgeWithEmailCode(judgePage, JUDGE_EMAIL);
     }
+
+    await openVoteDialog(judgePage, "Harbor Pulse");
+    await expect(judgePage.getByRole("heading", { name: "Voting is paused" })).toBeVisible();
+    await judgePage.getByRole("button", { name: "Close" }).click();
 
     let voteDialog = await openVoteDialog(judgePage, "Aurora Atlas");
     await expect(voteDialog.getByTestId("score-option-7")).toBeFocused();
@@ -352,6 +382,14 @@ test("manager, judges, and public users complete the single-screen voting flow",
         .nth(activeResponsiveIndex(testInfo.project.name))
     ).toContainText("7", { timeout: 12000 });
 
+    await managerPage.goto("/");
+    await managerPage
+      .getByTestId("manager-entry-toggle-harbor-pulse")
+      .nth(activeResponsiveIndex(testInfo.project.name))
+      .click();
+    await expect(managerPage.getByText("Harbor Pulse is now open for judging again.")).toBeVisible();
+
+    await judgePage.goto("/");
     await openVoteDialog(judgePage, "Harbor Pulse");
     await saveVote(judgePage, 6);
 
@@ -382,7 +420,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await expect(managerPage.getByText("5/5")).toBeVisible();
     await expect(
       managerPage.getByText(
-        "Every participating judge has scored every project they are eligible to judge. The manager can finalize the results."
+        "Every participating judge has scored every project that is still open for them. The manager can finalize the results."
       )
     ).toBeVisible();
 
@@ -425,7 +463,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
     managerPage.once("dialog", (dialog) => void dialog.accept());
     await managerPage.getByTestId("manager-reset-round").click();
     await expect(managerPage.getByText("Competition reset. Upload a fresh workbook to start the next dry run.")).toBeVisible();
-    await expect(managerPage.getByText("No projects loaded yet")).toBeVisible();
+    await expect(managerPage.getByTestId("scoreboard-empty-heading")).toBeVisible();
     await expect(managerPage.getByTestId("manager-begin-voting")).toBeDisabled();
     await expect(managerPage.getByTestId("manager-upload-button")).toBeEnabled();
 
@@ -437,10 +475,10 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await expect(managerPage.getByText("Imported 3 projects.")).toBeVisible();
     managerPage.once("dialog", (dialog) => void dialog.accept());
     await managerPage.getByTestId("manager-reset-round").click();
-    await expect(managerPage.getByText("No projects loaded yet")).toBeVisible();
+    await expect(managerPage.getByTestId("scoreboard-empty-heading")).toBeVisible();
 
     await anonymousPage.goto("/");
-    await expect(anonymousPage.getByText("No projects loaded yet")).toBeVisible();
+    await expect(anonymousPage.getByTestId("scoreboard-empty-heading")).toBeVisible();
     await takeShot(managerPage, testInfo.outputPath("manager-reset-empty-state.png"));
   });
 

--- a/tests/votes.integration.test.ts
+++ b/tests/votes.integration.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { COMPETITION_STATE_ID, MANAGER_EMAIL } from "@/lib/constants";
 import { prisma } from "@/lib/prisma";
-import { resetCompetitionRound, submitJudgeVote } from "@/lib/competition";
+import { resetCompetitionRound, setEntryVotingAvailability, submitJudgeVote } from "@/lib/competition";
 
 async function resetDatabase() {
   await prisma.vote.deleteMany();
@@ -95,6 +95,32 @@ describe("submitJudgeVote", () => {
         score: 9
       })
     ).rejects.toThrow("Team members cannot vote on their own project.");
+  });
+
+  it("blocks new votes when the manager closes a project", async () => {
+    const entry = await prisma.entry.create({
+      data: {
+        slug: "signal-bloom",
+        projectName: "Signal Bloom",
+        teamEmails: {
+          create: [{ email: "builder@example.com" }]
+        }
+      }
+    });
+
+    await setEntryVotingAvailability({
+      entryId: entry.id,
+      isVotingOpen: false
+    });
+
+    await expect(
+      submitJudgeVote({
+        entryId: entry.id,
+        judgeEmail: "judge@example.com",
+        judgeUserId: "user_2",
+        score: 9
+      })
+    ).rejects.toThrow("Voting is currently closed for this project.");
   });
 
   it("resets the round back to an empty preparing state", async () => {


### PR DESCRIPTION
## Summary
- collapse the app into a true single-column flow with manager setup above the board and progress below it
- add scoreboard table and horizontal bar-chart modes plus manager row controls to open or close voting per project
- update backend rules, migration, tests, and docs so closed projects drop out of the live completion denominator until reopened

## Validation
- pnpm check
- pnpm test
- pnpm build
- pnpm test:e2e
- pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list
- LAYOUT_PROOF=1 pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
- curl -I https://vote.rajeevg.com
- E2E_BASE_URL=https://vote.rajeevg.com E2E_JUDGE_AUTH_MODE=ticket pnpm test:e2e
- LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managers can now close or reopen individual projects for voting while keeping them visible on the scoreboard
  * Scoreboard now supports toggling between table and horizontal bar-chart views
  * Added "Voting is paused" messaging when voting is unavailable for a project
  * Progress tracking now counts only open projects toward completion

* **Documentation**
  * Updated guides to reflect per-entry voting controls and scoreboard view modes

* **Tests**
  * Expanded test coverage for new manager controls and scoreboard visualizations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->