### PR TITLE
gh-20 refine judge visibility and voting tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The screen stays single-column across viewports so the scoreboard leads and judg
 - Authenticated judge voting in a modal
 - Automatic self-vote blocking from uploaded team-member emails
 - Live judging progress
+- Manager-only remaining-votes tracker that mirrors the real finalization denominator
 - Table and horizontal bar-chart views on the same scoreboard
 - Manager-only per-entry voting open/closed controls
 - Manager-only finalization and finalized XLSX export
@@ -168,10 +169,12 @@ The Playwright suite covers:
 - manager template download
 - manager workbook upload
 - manager per-entry open / close control
+- manager remaining-votes tracker
 - manager begin voting
 - scoreboard table / bar-chart toggle
 - email-code judge auth
 - modal keyboard voting
+- compact modal that fits above the fold on both proof viewports
 - self-vote blocking
 - single locked vote per judge per project
 - progress completion

--- a/components/results-dashboard.tsx
+++ b/components/results-dashboard.tsx
@@ -12,6 +12,7 @@ import {
   Play,
   RotateCcw,
   ShieldCheck,
+  TimerReset,
   Trophy
 } from "lucide-react";
 
@@ -26,12 +27,42 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 
-function statusCopy(status: CompetitionSnapshot["status"]) {
+function statusCopy({
+  status,
+  isManager
+}: {
+  status: CompetitionSnapshot["status"];
+  isManager: boolean;
+}) {
+  if (!isManager) {
+    if (status === "PREPARING") {
+      return {
+        eyebrow: "Public scoreboard",
+        headline: "The field is visible now, and judging opens when the manager is ready.",
+        body: "You can follow the live rankings without signing in. Once the round opens, judges can sign in and score directly from the modal."
+      };
+    }
+
+    if (status === "OPEN") {
+      return {
+        eyebrow: "Voting live",
+        headline: "The scoreboard is the room's shared source of truth.",
+        body: "Signed-in judges can cast one locked score on each project that is still open for voting. Closed projects stay visible, but they stop taking new votes."
+      };
+    }
+
+    return {
+      eyebrow: "Finalized",
+      headline: "The final standings are locked in.",
+      body: "Judging is complete. Everyone sees the same final scoreboard, and no more votes can be added."
+    };
+  }
+
   if (status === "PREPARING") {
     return {
-      eyebrow: "Manager setup",
-      headline: "Load the workbook, tighten the field, then open judging.",
-      body: "The scoreboard is already public. Use the controls below to upload entries, close any project that should stay out of the round, and start only when the room is ready."
+      eyebrow: "Round control",
+      headline: "The public scoreboard is live, and judging opens when the room is ready.",
+      body: "Use the manager controls below to upload entries, close any project that should stay out of the round, and open judging only when the field is exactly right."
     };
   }
 
@@ -123,7 +154,10 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
   const [actionMessage, setActionMessage] = React.useState<string | null>(null);
   const [authDialogOpen, setAuthDialogOpen] = React.useState(false);
   const uploadInputRef = React.useRef<HTMLInputElement>(null);
-  const copy = statusCopy(snapshot.status);
+  const copy = statusCopy({
+    status: snapshot.status,
+    isManager: snapshot.viewer.isManager
+  });
   const stateMeta = progressStateMeta(snapshot.status);
   const isEmpty = snapshot.entries.length === 0;
   const scoreboardMeta = scoreboardCopy(snapshot, isEmpty);
@@ -285,7 +319,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
 
         <section className="space-y-4" data-testid="workflow-summary">
           <div className="glass-panel shell-surface rounded-[2rem] px-5 py-5 sm:px-6 sm:py-6">
-            <div className="max-w-4xl">
+            <div className={cn("max-w-4xl", snapshot.viewer.isManager ? "" : "max-w-3xl")}>
               <div className="eyebrow">{copy.eyebrow}</div>
               <h1 className="mt-3 font-display text-[clamp(2rem,4vw,3.35rem)] font-black tracking-tight text-foreground">
                 Live hackathon scoreboard
@@ -302,6 +336,11 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
               <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
                 {snapshot.progress.openEntryCount} open for voting
               </span>
+              {snapshot.viewer.isManager && snapshot.status === "OPEN" ? (
+                <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                  {snapshot.managerTracker.totalRemainingVotes} votes left
+                </span>
+              ) : null}
               <span
                 className={cn(
                   "rounded-full px-3 py-2",
@@ -403,7 +442,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                         <div className="text-sm text-muted-foreground">
                           {snapshot.canUploadSheet
                             ? "Upload is available now."
-                            : "Upload unlocks again after you reset the round back to manager setup."}
+                            : "Upload unlocks again after you reset the round."}
                         </div>
                       </div>
                     </div>
@@ -637,6 +676,112 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
               <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                 Board refreshes automatically every {Math.round(autoRefreshIntervalMs / 1000)} seconds while this tab is active.
               </div>
+
+              {snapshot.viewer.isManager ? (
+                <div
+                  className="rounded-[1.7rem] border border-border/80 bg-radix-gray-a-3/70 p-4 sm:p-5"
+                  data-testid="manager-remaining-votes"
+                >
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="max-w-2xl">
+                      <div className="eyebrow">Remaining votes tracker</div>
+                      <div className="mt-2 text-lg font-semibold text-foreground">
+                        {snapshot.status === "OPEN"
+                          ? snapshot.managerTracker.totalRemainingVotes === 0
+                            ? "Everyone who joined the round is fully covered."
+                            : `${snapshot.managerTracker.totalRemainingVotes} vote${snapshot.managerTracker.totalRemainingVotes === 1 ? "" : "s"} still outstanding.`
+                          : "This tracker activates once judging is live."}
+                      </div>
+                      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                        {snapshot.managerTracker.helperText}
+                      </p>
+                    </div>
+
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <div className="rounded-[1.35rem] border border-border/70 bg-background/35 px-4 py-3">
+                        <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                          Votes left
+                        </div>
+                        <div className="mt-2 font-display text-3xl font-black text-foreground">
+                          {snapshot.managerTracker.totalRemainingVotes}
+                        </div>
+                      </div>
+                      <div className="rounded-[1.35rem] border border-border/70 bg-background/35 px-4 py-3">
+                        <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                          Judges waiting
+                        </div>
+                        <div className="mt-2 font-display text-3xl font-black text-foreground">
+                          {snapshot.managerTracker.judgesStillOutstanding}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {snapshot.managerTracker.judges.length > 0 ? (
+                    <div className="mt-5 space-y-3">
+                      {snapshot.managerTracker.judges.map((judge) => (
+                        <div
+                          key={judge.judgeEmail}
+                          className="rounded-[1.4rem] border border-border/70 bg-background/30 p-4"
+                          data-testid={`manager-judge-coverage-${judge.judgeEmail.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`}
+                        >
+                          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                            <div className="min-w-0">
+                              <div className="truncate text-sm font-semibold text-foreground">{judge.judgeEmail}</div>
+                              <div className="mt-1 text-sm text-muted-foreground">
+                                {judge.completedOpenEntries}/{judge.eligibleOpenEntries} open projects covered
+                              </div>
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                              <span
+                                className={cn(
+                                  "rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em]",
+                                  judge.remainingOpenEntries === 0
+                                    ? "bg-radix-teal-a-3 text-accent-foreground"
+                                    : "bg-radix-amber-a-3 text-foreground"
+                                )}
+                              >
+                                {judge.remainingOpenEntries === 0
+                                  ? "Complete"
+                                  : `${judge.remainingOpenEntries} left`}
+                              </span>
+                              {judge.lastActivityAt ? (
+                                <span className="inline-flex items-center gap-1 rounded-full bg-radix-gray-a-3 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                                  <TimerReset className="h-3.5 w-3.5" />
+                                  Active
+                                </span>
+                              ) : null}
+                            </div>
+                          </div>
+
+                          {judge.remainingProjectNames.length > 0 ? (
+                            <div className="mt-3 flex flex-wrap gap-2">
+                              {judge.remainingProjectNames.map((projectName) => (
+                                <span
+                                  key={`${judge.judgeEmail}-${projectName}`}
+                                  className="rounded-full bg-radix-gray-a-3 px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+                                >
+                                  {projectName}
+                                </span>
+                              ))}
+                            </div>
+                          ) : (
+                            <div className="mt-3 text-sm text-muted-foreground">
+                              No remaining open projects for this judge.
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="mt-5 rounded-[1.4rem] border border-border/70 bg-background/30 p-4 text-sm leading-6 text-muted-foreground">
+                      {snapshot.status === "OPEN"
+                        ? "No one has cast a score yet, so there is no active judge list to track."
+                        : "Once the round is live and the first score comes in, this panel will list exactly who is still outstanding."}
+                    </div>
+                  )}
+                </div>
+              ) : null}
             </CardContent>
           </Card>
         </section>

--- a/components/vote-dialog.tsx
+++ b/components/vote-dialog.tsx
@@ -119,23 +119,23 @@ export function VoteDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[min(96vw,70rem)] overflow-hidden border-border/90 p-0">
-        <div className="grid max-h-[94vh] overflow-y-auto lg:grid-cols-[1.08fr_0.92fr]">
-          <div className="shell-surface content-grid relative border-b border-border p-5 md:p-7 lg:border-b-0 lg:border-r lg:p-8">
-            <div className="absolute inset-x-0 top-0 h-28 bg-[radial-gradient(circle_at_top_left,var(--hero-glow),transparent_72%)]" />
-            <DialogHeader className="relative">
+      <DialogContent className="w-[min(96vw,58rem)] overflow-hidden border-border/90 p-0">
+        <div className="shell-surface relative max-h-[88vh] overflow-y-auto px-4 py-4 sm:px-6 sm:py-5">
+          <div className="absolute inset-x-0 top-0 h-24 bg-[radial-gradient(circle_at_top_left,var(--hero-glow),transparent_72%)]" />
+          <div className="relative space-y-4">
+            <DialogHeader className="space-y-2">
               <div className="eyebrow">Judge vote</div>
-              <DialogTitle className="max-w-2xl text-[clamp(2.15rem,4vw,3.4rem)] leading-[0.95]">
+              <DialogTitle className="max-w-3xl text-[clamp(1.85rem,3vw,2.55rem)] leading-[0.95]">
                 {entry.projectName}
               </DialogTitle>
-              <DialogDescription className="max-w-xl text-[0.95rem] leading-8">
+              <DialogDescription className="max-w-3xl text-sm leading-6">
                 {entry.summary ??
-                  "Capture the energy of the project in one clear score from 0 to 10. Judges get one shot per project, so the interaction should feel decisive and obvious."}
+                  "Capture the energy of the project in one clear score from 0 to 10. Judges get one decisive vote per project, so everything here is designed to be fast and obvious."}
               </DialogDescription>
             </DialogHeader>
 
-            <div className="relative mt-6 space-y-4">
-              <div className="glass-panel rounded-[1.9rem] p-5">
+            <div className="grid gap-3 lg:grid-cols-[1.05fr_0.95fr]">
+              <div className="rounded-[1.5rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4">
                 <div className="flex flex-wrap items-center gap-2">
                   {entry.teamName ? (
                     <span className="rounded-full bg-radix-gray-a-3 px-3 py-1 text-xs font-semibold text-muted-foreground">
@@ -145,294 +145,268 @@ export function VoteDialog({
                   <span className="rounded-full bg-radix-teal-a-3 px-3 py-1 text-xs font-semibold text-accent-foreground">
                     {entry.voteCount} submitted vote{entry.voteCount === 1 ? "" : "s"}
                   </span>
+                  <span
+                    className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${
+                      isEntryClosed ? "bg-radix-amber-a-3 text-foreground" : "bg-radix-gray-a-3 text-muted-foreground"
+                    }`}
+                  >
+                    {isEntryClosed ? "Voting paused" : "Voting active"}
+                  </span>
                 </div>
 
-                <div className="mt-6 grid gap-4 sm:grid-cols-[0.95fr_1.05fr]">
-                  <div className="rounded-[1.6rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-5">
+                <div className="mt-4 flex items-end justify-between gap-4">
+                  <div>
                     <div className="eyebrow">Live aggregate</div>
                     <div
-                      className="mt-3 font-display text-6xl font-black text-primary"
+                      className="mt-2 font-display text-4xl font-black text-primary sm:text-5xl"
                       data-testid="vote-dialog-aggregate-total"
                     >
                       {entry.totalScore}
                     </div>
-                    <div
-                      className="mt-3 text-sm font-medium text-muted-foreground"
-                      data-testid="vote-dialog-aggregate-summary"
-                    >
-                      {entry.averageScore == null
-                        ? "No average yet"
-                        : `${entry.averageScore} average across ${entry.voteCount} vote${entry.voteCount === 1 ? "" : "s"}`}
-                    </div>
                   </div>
-
-                  <div className="rounded-[1.6rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-5">
-                    <div className="eyebrow">Judging stance</div>
-                    <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em]">
-                      <span className="rounded-full bg-radix-gray-a-3 px-3 py-2 text-muted-foreground">
-                        0-3 Stretch
-                      </span>
-                      <span className="rounded-full bg-radix-purple-a-4 px-3 py-2 text-foreground">
-                        4-7 Strong
-                      </span>
-                      <span className="rounded-full bg-radix-teal-a-4 px-3 py-2 text-accent-foreground">
-                        8-10 Winner
-                      </span>
-                    </div>
-                    <p className="mt-4 text-sm leading-7 text-muted-foreground">
-                      Choose the number that best captures your conviction. Once you submit, that vote locks immediately for the rest of the round.
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              {hasRecordedVote ? (
-                <div className="rounded-[1.7rem] border border-radix-teal-a-6 bg-radix-teal-a-3 p-5 text-accent-foreground">
-                  <div className="flex flex-wrap items-center gap-3">
-                    <CheckCircle2 className="h-5 w-5" />
-                    <span className="text-sm font-semibold uppercase tracking-[0.2em]">Recorded score</span>
-                  </div>
-                  <div className="mt-4 flex flex-wrap items-end gap-4">
-                    <div className="font-display text-5xl font-black">{entry.currentUserVote}</div>
-                    <div className="pb-2 text-sm font-medium">
-                      <div>{recordedVote?.band}</div>
-                      <div>{recordedVote?.summary}</div>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-
-              {isBlocked ? (
-                <div className="rounded-[1.6rem] border border-[rgb(217_140_20_/_0.28)] bg-[rgb(217_140_20_/_0.08)] p-5 text-sm leading-7 text-foreground">
-                  Self-voting is blocked automatically because your signed-in email matches a submitted team email for this project.
-                </div>
-              ) : null}
-
-              {isEntryClosed && !hasRecordedVote && status === "OPEN" ? (
-                <div className="rounded-[1.6rem] border border-[rgb(217_140_20_/_0.28)] bg-[rgb(217_140_20_/_0.08)] p-5 text-sm leading-7 text-foreground">
-                  Voting is paused for this project right now. The manager can reopen it from the scoreboard at any time.
-                </div>
-              ) : null}
-
-              {errorMessage ? (
-                <div
-                  aria-live="polite"
-                  className="rounded-[1.6rem] border border-[rgb(204_63_79_/_0.25)] bg-[rgb(204_63_79_/_0.08)] p-4 text-sm text-foreground"
-                >
-                  {errorMessage}
-                </div>
-              ) : null}
-            </div>
-          </div>
-
-          <div className="relative p-5 md:p-7 lg:p-8">
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,var(--hero-glow),transparent_55%)]" />
-            <div className="relative flex h-full flex-col">
-              <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-muted-foreground">
-                <Sparkles className="h-4 w-4 text-primary" />
-                <span>The score pad is fully keyboard friendly and optimized for quick judging.</span>
-              </div>
-
-              {isLocked ? (
-                <div className="glass-panel flex flex-1 flex-col justify-center rounded-[1.9rem] p-6 sm:p-7">
-                  <h3 className="font-display text-3xl font-black">
-                    {status === "PREPARING" ? "Voting opens soon" : "Judging is finalized"}
-                  </h3>
-                  <p className="mt-4 max-w-md text-sm leading-7 text-muted-foreground">
-                    {status === "PREPARING"
-                      ? "The board is visible already, but the manager has not opened the round yet."
-                      : "Finalized results are locked now. Thanks for helping judge the field."}
-                  </p>
-                </div>
-              ) : hasRecordedVote ? (
-                <div className="glass-panel flex flex-1 flex-col justify-between rounded-[1.9rem] p-6 sm:p-7">
-                  <div>
-                    <div className="eyebrow">Vote locked</div>
-                    <h3 className="mt-2 font-display text-3xl font-black">Score recorded</h3>
-                    <p className="mt-4 max-w-md text-sm leading-7 text-muted-foreground">
-                      Each judge gets one vote per project in this round. Your score is already on the board and cannot be changed now.
-                    </p>
-                  </div>
-
-                  <div className="mt-6 rounded-[1.7rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-5">
-                    <div className="flex items-center gap-3">
-                      <LockKeyhole className="h-5 w-5 text-primary" />
-                      <span className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                        Your submitted score
-                      </span>
-                    </div>
-                    <div className="mt-4 flex items-end gap-4">
-                      <div className="font-display text-6xl font-black text-foreground">{entry.currentUserVote}</div>
-                      <div className="pb-2 text-sm text-muted-foreground">
-                        <div className="font-semibold text-foreground">{recordedVote?.band}</div>
-                        <div>{recordedVote?.summary}</div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : isEntryClosed ? (
-                <div className="glass-panel flex flex-1 flex-col justify-center rounded-[1.9rem] p-6 sm:p-7">
-                  <h3 className="font-display text-3xl font-black">Voting is paused</h3>
-                  <p className="mt-4 max-w-md text-sm leading-7 text-muted-foreground">
-                    This project is still visible on the public board, but the manager has closed it to new votes for now.
-                  </p>
-                </div>
-              ) : needsAuth ? (
-                <div className="glass-panel flex flex-1 flex-col justify-between rounded-[1.9rem] p-6 sm:p-7">
-                  <JudgeAuthPanel
-                    afterAuthenticate={() => {
-                      onVoteSaved();
-                    }}
-                    description="The board stays public, but signing in unlocks a single decisive score per project. Once you submit, that score is locked for the round."
-                    title="Sign in to cast your vote"
-                  />
-                </div>
-              ) : isBlocked ? (
-                <div className="glass-panel flex flex-1 flex-col justify-center rounded-[1.9rem] p-6 sm:p-7">
-                  <h3 className="font-display text-3xl font-black">You can’t score this one</h3>
-                  <p className="mt-4 max-w-md text-sm leading-7 text-muted-foreground">
-                    We block self-voting automatically so judges never need to second-guess whether a score is allowed.
-                  </p>
-                </div>
-              ) : (
-                <div className="glass-panel flex flex-1 flex-col rounded-[1.9rem] p-5">
-                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                    <div>
-                      <div className="eyebrow">Cast your only vote</div>
-                      <h3 className="mt-2 font-display text-3xl font-black">Make it count</h3>
-                    </div>
-                    <div className="inline-flex items-center rounded-full bg-radix-gray-a-3 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                      No edits after submit
-                    </div>
-                  </div>
-
-                  <div className="mt-5 rounded-[1.6rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4">
-                    <div className="flex flex-wrap items-start justify-between gap-4">
-                      <div>
-                        <div className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                          Selected score
-                        </div>
-                        <div className="mt-3 flex items-end gap-4">
-                          <div className="font-display text-6xl font-black text-primary">{previewScore}</div>
-                          <div className="pb-2">
-                            <div className="text-lg font-semibold text-foreground">{preview.band}</div>
-                            <div className="max-w-xs text-sm leading-7 text-muted-foreground">
-                              {preview.summary}
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        className={`rounded-full px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] ${preview.accentClassName}`}
-                      >
-                        {preview.band}
-                      </div>
-                    </div>
-                  </div>
-
-                  <RadioGroup
-                    className="mt-5 grid grid-cols-4 gap-2.5 sm:grid-cols-4 lg:grid-cols-4"
-                    value={selectedScore}
-                    onValueChange={setSelectedScore}
+                  <div
+                    className="max-w-[15rem] text-right text-sm leading-6 text-muted-foreground"
+                    data-testid="vote-dialog-aggregate-summary"
                   >
-                    {scoreOptions.map((value) => {
-                      const tone = describeScore(value);
-
-                      return (
-                        <RadioGroupItem
-                          aria-label={`Score ${value}, ${tone.band}`}
-                          autoFocus={value === 7}
-                          key={value}
-                          value={String(value)}
-                          className="group relative flex aspect-[0.98] min-h-[72px] flex-col items-start justify-between overflow-hidden rounded-[1.55rem] border-border/80 bg-[rgb(255_255_255_/_0.03)] p-3.5 text-left hover:-translate-y-0.5 data-[state=checked]:shadow-[0_18px_50px_var(--shadow-soft)] sm:min-h-[84px]"
-                          data-testid={`score-option-${value}`}
-                        >
-                          <span className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-transparent via-radix-teal-a-6 to-transparent opacity-0 transition group-data-[state=checked]:opacity-100" />
-                          <span className="font-display text-[2rem] font-black leading-none sm:text-[2.15rem]">{value}</span>
-                          <span className="text-[0.62rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground group-data-[state=checked]:text-accent-foreground">
-                            {tone.band}
-                          </span>
-                        </RadioGroupItem>
-                      );
-                    })}
-                  </RadioGroup>
-
-                  <p className="mt-4 text-sm leading-6 text-muted-foreground">
-                    Tab into the score grid, then use arrow keys and press space or enter to choose.
-                  </p>
-
-                  <div className="mt-auto pt-5">
-                    <AnimatePresence mode="wait">
-                      {state === "success" ? (
-                        <motion.div
-                          key="vote-success"
-                          animate={{ opacity: 1, y: 0 }}
-                          aria-live="polite"
-                          className="rounded-[1.7rem] border border-radix-teal-a-6 bg-radix-teal-a-3 p-4 text-accent-foreground shadow-halo"
-                          data-testid="vote-saved-toast"
-                          exit={{ opacity: 0, y: 10 }}
-                          initial={{ opacity: 0, y: 14 }}
-                          role="status"
-                        >
-                          <div className="flex items-start gap-3">
-                            <div className="mt-1 rounded-full bg-[rgb(255_255_255_/_0.14)] p-2">
-                              <CheckCircle2 className="h-5 w-5" />
-                            </div>
-                            <div>
-                              <div className="text-sm font-semibold uppercase tracking-[0.18em]">
-                                Vote locked in
-                              </div>
-                              <div className="mt-2 font-display text-2xl font-black">
-                                {previewScore} points recorded
-                              </div>
-                              <div className="mt-2 text-sm leading-7">
-                                Your score is live on the board now. This project is locked for the rest of the round.
-                              </div>
-                            </div>
-                          </div>
-                        </motion.div>
-                      ) : (
-                        <motion.div
-                          key="vote-cta"
-                          animate={{ opacity: 1, y: 0 }}
-                          className="rounded-[1.7rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4"
-                          exit={{ opacity: 0, y: 10 }}
-                          initial={{ opacity: 0, y: 14 }}
-                        >
-                          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                            <div className="min-w-0">
-                              <div className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                                Ready to submit
-                              </div>
-                              <div className="mt-2 text-sm leading-7 text-muted-foreground">
-                                You are about to lock{" "}
-                                <span className="font-semibold text-foreground">{previewScore}</span> for this project.
-                              </div>
-                            </div>
-                            <Button
-                              className="min-w-[220px] justify-center"
-                              data-testid="submit-vote"
-                              disabled={!selectedScore || state === "submitting"}
-                              onClick={submitVote}
-                              size="lg"
-                            >
-                              {state === "submitting" ? (
-                                "Locking vote..."
-                              ) : (
-                                <>
-                                  Lock score
-                                  <ArrowRight className="h-4 w-4" />
-                                </>
-                              )}
-                            </Button>
-                          </div>
-                        </motion.div>
-                      )}
-                    </AnimatePresence>
+                    {entry.averageScore == null
+                      ? "No average yet"
+                      : `${entry.averageScore} average across ${entry.voteCount} vote${entry.voteCount === 1 ? "" : "s"}`}
                   </div>
                 </div>
-              )}
+              </div>
+
+              <div className="rounded-[1.5rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4">
+                <div className="flex items-center gap-2 text-sm font-semibold text-muted-foreground">
+                  <Sparkles className="h-4 w-4 text-primary" />
+                  <span>Keyboard friendly and optimized for quick judging.</span>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.16em]">
+                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-1.5 text-muted-foreground">0-3 Stretch</span>
+                  <span className="rounded-full bg-radix-purple-a-4 px-3 py-1.5 text-foreground">4-7 Strong</span>
+                  <span className="rounded-full bg-radix-teal-a-4 px-3 py-1.5 text-accent-foreground">8-10 Winner</span>
+                </div>
+                <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                  Choose the number that matches your conviction. Once you submit, that vote locks for the rest of the round.
+                </p>
+              </div>
             </div>
+
+            {hasRecordedVote ? (
+              <div className="rounded-[1.45rem] border border-radix-teal-a-6 bg-radix-teal-a-3 p-4 text-accent-foreground">
+                <div className="flex flex-wrap items-center gap-3">
+                  <CheckCircle2 className="h-5 w-5" />
+                  <span className="text-sm font-semibold uppercase tracking-[0.18em]">Recorded score</span>
+                </div>
+                <div className="mt-3 flex flex-wrap items-end gap-4">
+                  <div className="font-display text-4xl font-black sm:text-5xl">{entry.currentUserVote}</div>
+                  <div className="pb-1 text-sm font-medium">
+                    <div>{recordedVote?.band}</div>
+                    <div>{recordedVote?.summary}</div>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            {isBlocked ? (
+              <div className="rounded-[1.4rem] border border-[rgb(217_140_20_/_0.28)] bg-[rgb(217_140_20_/_0.08)] p-4 text-sm leading-6 text-foreground">
+                Self-voting is blocked automatically because your signed-in email matches a submitted team email for this project.
+              </div>
+            ) : null}
+
+            {isEntryClosed && !hasRecordedVote && status === "OPEN" ? (
+              <div className="rounded-[1.4rem] border border-[rgb(217_140_20_/_0.28)] bg-[rgb(217_140_20_/_0.08)] p-4 text-sm leading-6 text-foreground">
+                Voting is paused for this project right now. The manager can reopen it from the scoreboard at any time.
+              </div>
+            ) : null}
+
+            {errorMessage ? (
+              <div
+                aria-live="polite"
+                className="rounded-[1.4rem] border border-[rgb(204_63_79_/_0.25)] bg-[rgb(204_63_79_/_0.08)] p-4 text-sm text-foreground"
+              >
+                {errorMessage}
+              </div>
+            ) : null}
+
+            {isLocked ? (
+              <div className="glass-panel rounded-[1.7rem] p-5 sm:p-6">
+                <h3 className="font-display text-2xl font-black">
+                  {status === "PREPARING" ? "Voting opens soon" : "Judging is finalized"}
+                </h3>
+                <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+                  {status === "PREPARING"
+                    ? "The board is visible already, but the manager has not opened the round yet."
+                    : "Finalized results are locked now. Thanks for helping judge the field."}
+                </p>
+              </div>
+            ) : hasRecordedVote ? (
+              <div className="glass-panel rounded-[1.7rem] p-5 sm:p-6">
+                <div className="eyebrow">Vote locked</div>
+                <h3 className="mt-2 font-display text-2xl font-black">Score recorded</h3>
+                <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+                  Each judge gets one vote per project in this round. Your score is already on the board and cannot be changed now.
+                </p>
+              </div>
+            ) : isEntryClosed ? (
+              <div className="glass-panel rounded-[1.7rem] p-5 sm:p-6">
+                <h3 className="font-display text-2xl font-black">Voting is paused</h3>
+                <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+                  This project is still visible on the public board, but the manager has closed it to new votes for now.
+                </p>
+              </div>
+            ) : needsAuth ? (
+              <div className="glass-panel rounded-[1.7rem] p-5 sm:p-6">
+                <JudgeAuthPanel
+                  afterAuthenticate={() => {
+                    onVoteSaved();
+                  }}
+                  description="The board stays public, but signing in unlocks a single decisive score per project. Once you submit, that score is locked for the round."
+                  title="Sign in to cast your vote"
+                />
+              </div>
+            ) : isBlocked ? (
+              <div className="glass-panel rounded-[1.7rem] p-5 sm:p-6">
+                <h3 className="font-display text-2xl font-black">You can’t score this one</h3>
+                <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+                  We block self-voting automatically so judges never need to second-guess whether a score is allowed.
+                </p>
+              </div>
+            ) : (
+              <div className="glass-panel rounded-[1.7rem] p-4 sm:p-5" data-testid="vote-dialog-fit-surface">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <div className="eyebrow">Cast your only vote</div>
+                    <h3 className="mt-2 font-display text-2xl font-black sm:text-[2rem]">Make it count</h3>
+                  </div>
+                  <div className="inline-flex items-center rounded-full bg-radix-gray-a-3 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                    No edits after submit
+                  </div>
+                </div>
+
+                <div className="mt-4 rounded-[1.4rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4">
+                  <div className="flex flex-wrap items-end justify-between gap-3">
+                    <div>
+                      <div className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                        Selected score
+                      </div>
+                      <div className="mt-2 flex items-end gap-3">
+                        <div className="font-display text-5xl font-black text-primary sm:text-6xl">{previewScore}</div>
+                        <div className="pb-1">
+                          <div className="text-base font-semibold text-foreground">{preview.band}</div>
+                          <div className="max-w-xs text-sm leading-6 text-muted-foreground">{preview.summary}</div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className={`rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] ${preview.accentClassName}`}
+                    >
+                      {preview.band}
+                    </div>
+                  </div>
+                </div>
+
+                <RadioGroup
+                  className="mt-4 grid grid-cols-4 gap-2 sm:grid-cols-6"
+                  value={selectedScore}
+                  onValueChange={setSelectedScore}
+                >
+                  {scoreOptions.map((value) => {
+                    const tone = describeScore(value);
+
+                    return (
+                      <RadioGroupItem
+                        aria-label={`Score ${value}, ${tone.band}`}
+                        autoFocus={value === 7}
+                        key={value}
+                        value={String(value)}
+                        className="group relative flex min-h-[64px] flex-col items-start justify-between overflow-hidden rounded-[1.25rem] border-border/80 bg-[rgb(255_255_255_/_0.03)] px-3 py-2.5 text-left hover:-translate-y-0.5 data-[state=checked]:shadow-[0_18px_50px_var(--shadow-soft)] sm:min-h-[72px]"
+                        data-testid={`score-option-${value}`}
+                      >
+                        <span className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-transparent via-radix-teal-a-6 to-transparent opacity-0 transition group-data-[state=checked]:opacity-100" />
+                        <span className="font-display text-[1.6rem] font-black leading-none sm:text-[1.8rem]">{value}</span>
+                        <span className="text-[0.58rem] font-semibold uppercase tracking-[0.2em] text-muted-foreground group-data-[state=checked]:text-accent-foreground">
+                          {tone.band}
+                        </span>
+                      </RadioGroupItem>
+                    );
+                  })}
+                </RadioGroup>
+
+                <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                  Tab into the score grid, then use arrow keys and press space or enter to choose.
+                </p>
+
+                <div className="mt-4">
+                  <AnimatePresence mode="wait">
+                    {state === "success" ? (
+                      <motion.div
+                        key="vote-success"
+                        animate={{ opacity: 1, y: 0 }}
+                        aria-live="polite"
+                        className="rounded-[1.45rem] border border-radix-teal-a-6 bg-radix-teal-a-3 p-4 text-accent-foreground shadow-halo"
+                        data-testid="vote-saved-toast"
+                        exit={{ opacity: 0, y: 10 }}
+                        initial={{ opacity: 0, y: 14 }}
+                        role="status"
+                      >
+                        <div className="flex items-start gap-3">
+                          <div className="mt-1 rounded-full bg-[rgb(255_255_255_/_0.14)] p-2">
+                            <CheckCircle2 className="h-5 w-5" />
+                          </div>
+                          <div>
+                            <div className="text-sm font-semibold uppercase tracking-[0.18em]">
+                              Vote locked in
+                            </div>
+                            <div className="mt-1 font-display text-2xl font-black">
+                              {previewScore} points recorded
+                            </div>
+                            <div className="mt-1 text-sm leading-6">
+                              Your score is live on the board now. This project is locked for the rest of the round.
+                            </div>
+                          </div>
+                        </div>
+                      </motion.div>
+                    ) : (
+                      <motion.div
+                        key="vote-cta"
+                        animate={{ opacity: 1, y: 0 }}
+                        className="rounded-[1.45rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4"
+                        exit={{ opacity: 0, y: 10 }}
+                        initial={{ opacity: 0, y: 14 }}
+                      >
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="min-w-0">
+                            <div className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                              Ready to submit
+                            </div>
+                            <div className="mt-1 text-sm leading-6 text-muted-foreground">
+                              You are about to lock{" "}
+                              <span className="font-semibold text-foreground">{previewScore}</span> for this project.
+                            </div>
+                          </div>
+                          <Button
+                            className="min-w-[200px] justify-center"
+                            data-testid="submit-vote"
+                            disabled={!selectedScore || state === "submitting"}
+                            onClick={submitVote}
+                            size="lg"
+                          >
+                            {state === "submitting" ? (
+                              "Locking vote..."
+                            ) : (
+                              <>
+                                Lock score
+                                <ArrowRight className="h-4 w-4" />
+                              </>
+                            )}
+                          </Button>
+                        </div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </DialogContent>

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -7,6 +7,7 @@ The app is intentionally a single-screen product.
 - Public users land on `/` and can always see the live scoreboard.
 - The manager uses the same screen to download the XLSX template, upload entries, begin voting, finalize results, and export the final workbook.
 - The manager also uses the same scoreboard to close or reopen individual projects for new voting.
+- During open judging, the manager gets a remaining-votes tracker that shows exactly which participating judges still owe votes on which open projects.
 - Judges use the same screen to sign in and vote from the modal.
 - Legacy routes such as `/projects`, `/results`, and `/submission/assets` redirect back to `/`.
 
@@ -106,6 +107,7 @@ Every uploaded team-member email is stored against that project.
 - The manager clicks `Begin voting`.
 - Authenticated judges can vote.
 - The manager can pause voting on a specific project without removing it from the public board.
+- The manager can rely on the remaining-votes tracker to see who is still outstanding before closing individual projects or finalizing the round.
 - Public viewers can keep watching the board update live.
 - Active tabs refresh automatically every 5 seconds during judging, and inactive tabs refresh again when they regain focus.
 
@@ -124,6 +126,7 @@ The progress model is intentionally practical for hackathon use.
 - Projects a judge is self-vote-blocked from are removed from that judge's denominator.
 - Projects the manager has closed to new votes are also removed from the live denominator until reopened.
 - Completion means every participating judge has scored every project that is still open and eligible for them.
+- The manager tracker uses exactly that same denominator, so the list of outstanding judges and projects matches the finalization rule instead of a looser UI heuristic.
 
 This keeps the progress bar coherent without introducing heavy judge-roster administration.
 
@@ -149,7 +152,7 @@ See [/Users/rajeev/Code/hackathon-voting-prototype/prisma/schema.prisma](/Users/
 7. If you need a clean rehearsal, click `Reset dry run`, then upload again.
 8. Click `Begin voting` once the judges are ready.
 9. Ask judges to sign in once and vote from the modal.
-10. Watch the progress card until completion reaches `100%`.
+10. Watch the remaining-votes tracker and progress card together until no eligible votes are left.
 11. Click `Finalize`.
 12. Export the finalized workbook.
 

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -115,6 +115,7 @@ Self-vote blocking is derived from normalized email equality between the signed-
 - Public scoreboard stays visible.
 - Authenticated judges can vote.
 - The manager can close or reopen individual projects without removing them from the public board.
+- The manager sees a remaining-votes tracker that lists only participating judges, the open projects they still owe, and the total votes still outstanding.
 - A judge becomes part of the progress denominator the moment they cast their first score.
 - Each judge can submit exactly one score per project for the active round.
 - After submission, that project is locked for that judge unless the manager resets the whole round.
@@ -138,6 +139,7 @@ Completion is intentionally simple and operationally practical:
 - Entries the manager has closed to new votes are removed from the live denominator until reopened.
 - The round is complete when every participating judge has scored every project that is still open and eligible for them.
 - Finalization is available only when the round is `OPEN` and that completion rule is satisfied.
+- The manager tracker reuses the same eligibility logic so the outstanding list is trustworthy enough to use operationally during the event.
 
 This keeps the rule coherent without introducing a separate roster-management system.
 
@@ -159,6 +161,7 @@ This keeps the rule coherent without introducing a separate roster-management sy
   - keep project context visible
   - support keyboard-first scoring
   - announce feedback with live regions
+  - stay fully above the fold in the proven desktop and mobile judge flows
   - remain usable on mobile
 
 ## Event-day readiness notes

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -236,7 +236,9 @@ Viewports exercised:
 Behavior proof:
 
 - Public scoreboard is reachable without auth
+- Judges do not see manager-only controls or manager framing in the summary surface
 - Manager template download, workbook upload, begin-voting, per-entry close / reopen, finalization, and export all complete successfully
+- Manager remaining-votes tracker updates after the first submitted vote and mirrors the live completion denominator
 - Scoreboard table and horizontal bar-chart modes both render correctly
 - The vote modal opens from the scoreboard, accepts keyboard score selection, submits successfully, and then locks the judge out from changing that project
 - Self-vote blocking is enforced from uploaded team emails
@@ -246,7 +248,7 @@ Design proof notes:
 
 - Desktop uses the full width well without horizontal overflow
 - Mobile layout preserves the single-screen journey and keeps the modal legible and tappable
-- The modal remains the visual center of the flow on both viewports
+- The modal remains the visual center of the flow on both viewports while fitting above the fold in the judge proof run
 - The judging-progress state card now uses a friendly label plus helper copy, and fresh section proof confirmed no clipping or overlap in the status area
 
 Artifacts:

--- a/lib/competition-logic.ts
+++ b/lib/competition-logic.ts
@@ -53,6 +53,22 @@ export type ProgressSummary = {
   helperText: string;
 };
 
+export type JudgeCoverageSummary = {
+  judgeEmail: string;
+  eligibleOpenEntries: number;
+  completedOpenEntries: number;
+  remainingOpenEntries: number;
+  remainingProjectNames: string[];
+  lastActivityAt: string | null;
+};
+
+export type ManagerRoundTracker = {
+  totalRemainingVotes: number;
+  judgesStillOutstanding: number;
+  judges: JudgeCoverageSummary[];
+  helperText: string;
+};
+
 export type CompetitionSnapshot = {
   status: VotingStatus;
   startedAt: string | null;
@@ -61,6 +77,7 @@ export type CompetitionSnapshot = {
   viewer: ViewerIdentity;
   entries: ScoreboardEntryView[];
   progress: ProgressSummary;
+  managerTracker: ManagerRoundTracker;
   canDownloadTemplate: boolean;
   canUploadSheet: boolean;
   canBeginVoting: boolean;
@@ -208,6 +225,91 @@ export function deriveProgress({
   };
 }
 
+export function deriveManagerRoundTracker({
+  status,
+  entries
+}: {
+  status: VotingStatus;
+  entries: EntryRecordForLogic[];
+}): ManagerRoundTracker {
+  const openEntries = entries.filter((entry) => entry.isVotingOpen);
+  const participatingJudgeEmails = Array.from(
+    new Set(
+      openEntries.flatMap((entry) => entry.votes.map((vote) => normalizeEmail(vote.judgeEmail)))
+    )
+  );
+
+  if (status !== "OPEN") {
+    return {
+      totalRemainingVotes: 0,
+      judgesStillOutstanding: 0,
+      judges: [],
+      helperText:
+        status === "PREPARING"
+          ? "Judges appear here after the round opens and they cast their first score."
+          : "Judging is finalized. Every remaining-vote obligation is already resolved."
+    };
+  }
+
+  if (participatingJudgeEmails.length === 0) {
+    return {
+      totalRemainingVotes: 0,
+      judgesStillOutstanding: 0,
+      judges: [],
+      helperText:
+        "No judge has cast a vote yet. As soon as the first score arrives, this tracker will show who still has work left."
+    };
+  }
+
+  const judges = participatingJudgeEmails
+    .map((judgeEmail) => {
+      const eligibleOpenEntries = openEntries.filter((entry) => {
+        const entryEmails = entry.teamEmails.map((teamMember) => teamMember.email);
+        return !isSelfVoteBlocked(entryEmails, judgeEmail);
+      });
+      const completedOpenEntries = eligibleOpenEntries.filter((entry) =>
+        entry.votes.some((vote) => normalizeEmail(vote.judgeEmail) === judgeEmail)
+      );
+      const remainingEntries = eligibleOpenEntries.filter((entry) =>
+        entry.votes.every((vote) => normalizeEmail(vote.judgeEmail) !== judgeEmail)
+      );
+      const lastActivity = openEntries
+        .flatMap((entry) =>
+          entry.votes
+            .filter((vote) => normalizeEmail(vote.judgeEmail) === judgeEmail)
+            .map((vote) => vote.updatedAt)
+        )
+        .sort((left, right) => right.getTime() - left.getTime())[0];
+
+      return {
+        judgeEmail,
+        eligibleOpenEntries: eligibleOpenEntries.length,
+        completedOpenEntries: completedOpenEntries.length,
+        remainingOpenEntries: remainingEntries.length,
+        remainingProjectNames: remainingEntries.map((entry) => entry.projectName),
+        lastActivityAt: lastActivity?.toISOString() ?? null
+      };
+    })
+    .sort((left, right) => {
+      if (right.remainingOpenEntries !== left.remainingOpenEntries) {
+        return right.remainingOpenEntries - left.remainingOpenEntries;
+      }
+
+      return left.judgeEmail.localeCompare(right.judgeEmail);
+    });
+
+  const totalRemainingVotes = judges.reduce((sum, judge) => sum + judge.remainingOpenEntries, 0);
+  const judgesStillOutstanding = judges.filter((judge) => judge.remainingOpenEntries > 0).length;
+
+  return {
+    totalRemainingVotes,
+    judgesStillOutstanding,
+    judges,
+    helperText:
+      "Uses the same open-project and self-vote rules as finalization, so this is the trustworthy list of what is still outstanding."
+  };
+}
+
 export function deriveCompetitionSnapshot({
   status,
   startedAt,
@@ -222,6 +324,10 @@ export function deriveCompetitionSnapshot({
   viewer: ViewerIdentity;
 }): CompetitionSnapshot {
   const progress = deriveProgress({
+    status,
+    entries
+  });
+  const managerTracker = deriveManagerRoundTracker({
     status,
     entries
   });
@@ -279,6 +385,7 @@ export function deriveCompetitionSnapshot({
     viewer,
     entries: rankedEntries,
     progress,
+    managerTracker,
     canDownloadTemplate: viewer.isManager,
     canUploadSheet: viewer.isManager && status === "PREPARING",
     canBeginVoting: viewer.isManager && status === "PREPARING" && entries.some((entry) => entry.isVotingOpen),

--- a/tests/competition-logic.test.ts
+++ b/tests/competition-logic.test.ts
@@ -133,6 +133,62 @@ describe("competition logic", () => {
     expect(snapshot.entries.find((entry) => entry.id === "entry-2")?.canVote).toBe(false);
   });
 
+  it("builds a manager tracker that mirrors the live completion denominator", () => {
+    const snapshot = deriveCompetitionSnapshot({
+      status: "OPEN",
+      startedAt: new Date("2026-03-23T12:00:00.000Z"),
+      finalizedAt: null,
+      viewer: {
+        clerkUserId: "user_999",
+        email: "rajeev.gill@omc.com",
+        isAuthenticated: true,
+        isManager: true
+      },
+      entries: [
+        {
+          id: "entry-1",
+          slug: "aurora-atlas",
+          projectName: "Aurora Atlas",
+          teamName: "Team North Star",
+          summary: "Summary",
+          isVotingOpen: true,
+          teamEmails: [{ email: "founder@example.com" }],
+          votes: [{ judgeEmail: "judge.one@example.com", score: 9, updatedAt: new Date("2026-03-23T12:00:00.000Z") }]
+        },
+        {
+          id: "entry-2",
+          slug: "signal-bloom",
+          projectName: "Signal Bloom",
+          teamName: "Team Bloom",
+          summary: "Summary",
+          isVotingOpen: true,
+          teamEmails: [{ email: "judge.two@example.com" }],
+          votes: []
+        },
+        {
+          id: "entry-3",
+          slug: "harbor-pulse",
+          projectName: "Harbor Pulse",
+          teamName: "Team Harbor",
+          summary: "Summary",
+          isVotingOpen: false,
+          teamEmails: [{ email: "crew@example.com" }],
+          votes: []
+        }
+      ]
+    });
+
+    expect(snapshot.managerTracker.totalRemainingVotes).toBe(1);
+    expect(snapshot.managerTracker.judgesStillOutstanding).toBe(1);
+    expect(snapshot.managerTracker.judges[0]).toMatchObject({
+      judgeEmail: "judge.one@example.com",
+      eligibleOpenEntries: 2,
+      completedOpenEntries: 1,
+      remainingOpenEntries: 1,
+      remainingProjectNames: ["Signal Bloom"]
+    });
+  });
+
   it("recognizes the exact manager email", () => {
     expect(isManagerEmail("rajeev.gill@omc.com")).toBe(true);
     expect(isManagerEmail("Rajeev.Gill@omc.com")).toBe(true);

--- a/tests/e2e/single-screen-voting.spec.ts
+++ b/tests/e2e/single-screen-voting.spec.ts
@@ -180,6 +180,25 @@ async function openVoteDialog(page: Page, projectName: string) {
   return dialog;
 }
 
+async function expectDialogToFitViewport(page: Page) {
+  const dialog = page.getByRole("dialog");
+  const submitButton = page.getByTestId("submit-vote");
+
+  const measurements = await dialog.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      top: rect.top,
+      bottom: rect.bottom,
+      height: rect.height,
+      viewportHeight: window.innerHeight
+    };
+  });
+
+  expect(measurements.top).toBeGreaterThanOrEqual(0);
+  expect(measurements.bottom).toBeLessThanOrEqual(measurements.viewportHeight);
+  await expect(submitButton).toBeVisible();
+}
+
 async function saveVote(page: Page, score: number) {
   await page.getByTestId(`score-option-${score}`).click();
   await page.getByTestId("submit-vote").click();
@@ -264,6 +283,8 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await expect(anonymousPage.getByRole("heading", { name: "Live hackathon scoreboard" })).toBeVisible();
     await expect(anonymousPage.getByTestId("scoreboard-empty-heading")).toBeVisible();
     await expectProgressStateCardToContainValue(anonymousPage, "Preparing");
+    await expect(anonymousPage.getByText("Manager setup")).toHaveCount(0);
+    await expect(anonymousPage.getByText("Manager controls")).toHaveCount(0);
     await expect(anonymousPage.getByTestId("manager-download-template")).toHaveCount(0);
     await expect(anonymousPage.getByTestId("manager-upload-dropzone")).toHaveCount(0);
     await takeShot(anonymousPage, testInfo.outputPath("public-before-setup.png"));
@@ -346,6 +367,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await judgePage.getByRole("button", { name: "Close" }).click();
 
     let voteDialog = await openVoteDialog(judgePage, "Aurora Atlas");
+    await expectDialogToFitViewport(judgePage);
     await expect(voteDialog.getByTestId("score-option-7")).toBeFocused();
     await judgePage.keyboard.press("Space");
     await expect(voteDialog.getByTestId("score-option-7")).toHaveAttribute("data-state", "checked");
@@ -354,6 +376,21 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await expect(voteDialog.getByTestId("submit-vote")).toBeFocused();
     await judgePage.keyboard.press("Enter");
     await expect(judgePage.getByText("Judge", { exact: true })).toBeVisible();
+    await expect(
+      judgePage
+        .getByTestId("scoreboard-action-aurora-atlas")
+        .nth(activeResponsiveIndex(testInfo.project.name))
+    ).toContainText("Scored");
+    await expect(
+      judgePage
+        .getByTestId("scoreboard-row-aurora-atlas")
+        .nth(activeResponsiveIndex(testInfo.project.name))
+    ).toContainText("1 vote");
+
+    await managerPage.goto("/");
+    await expect(managerPage.getByTestId("manager-remaining-votes")).toContainText("1 vote still outstanding.");
+    await expect(managerPage.getByTestId("manager-remaining-votes")).toContainText(JUDGE_EMAIL);
+    await expect(managerPage.getByTestId("manager-remaining-votes")).toContainText("Signal Bloom");
 
     await openVoteDialog(judgePage, "Signal Bloom");
     await saveVote(judgePage, 7);


### PR DESCRIPTION
## Links
- Closes #20

## Scope
- remove manager-framed summary copy from the public and judge view while keeping manager controls private
- compact the vote modal so the scoring interaction fits above the fold in the proven desktop and mobile flows
- add a manager-only remaining-votes tracker that reuses the real completion and finalization denominator
- update docs and proof notes for the shipped behavior

## Validation
- `pnpm check`
- `pnpm exec vitest run tests/competition-logic.test.ts tests/votes.integration.test.ts tests/readiness.integration.test.ts --reporter=verbose`
- `pnpm build`
- `pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list`
- `pnpm test:e2e`
- `vercel --prod --yes`
- `curl -I https://vote.rajeevg.com`
- `set -a && source .env.vercel-prod && set +a && E2E_BASE_URL=https://vote.rajeevg.com E2E_JUDGE_AUTH_MODE=ticket pnpm test:e2e`
- `LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list`

## Acceptance notes
- judges and public viewers now get public-facing summary language instead of manager setup framing
- the vote dialog keeps the project context, score grid, and submit action within the viewport in the proven judge flows
- the manager tracker shows outstanding judges, remaining projects, and total votes left using the same rules as finalization
- production is updated at https://vote.rajeevg.com via https://hackathon-voting-prototype-8hgl2xjlj-rajeevgills-projects.vercel.app

## Follow-up risk
- the production ticket-based proof depends on the live Clerk secret; when the local env copy drifts, refresh it with `vercel env pull .env.vercel-prod --environment=production --yes` before rerunning production acceptance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Manager-only remaining votes tracker displaying judges' outstanding votes per project and activity status
  * Redesigned voting modal optimized to fit above the fold on mobile and desktop viewports
  * Role-specific messaging for managers and judges in the results dashboard

* **Documentation**
  * Updated guides documenting the manager remaining votes tracker and voting workflow
  * Clarified event-day checklist steps for monitoring voting progress

* **Tests**
  * Added comprehensive test coverage for manager tracker calculations and voting modal viewport fitting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->