### PR TITLE
gh-22 harden readiness consistency checks

### DIFF
--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -168,5 +168,6 @@ This keeps the rule coherent without introducing a separate roster-management sy
 
 - The production readiness target is a room-sized session of roughly 50 judges or viewers at once, not a viral public launch.
 - Signed-out scoreboard requests use a short server cache with explicit invalidation on voting lifecycle changes, which reduces repeated public read pressure on the database while keeping the board fresh.
+- The vote path tolerates a short read-after-write consistency window right after a round opens or a workbook-driven field is created, so immediate first votes are less likely to fail on pooled or remote Postgres infrastructure.
 - The repo includes a cheap public-read probe at `pnpm readiness:public` so the live site can be checked before the event without extra vendor spend.
 - Concurrent write readiness is covered in `tests/readiness.integration.test.ts`, which runs the real vote logic with 50 concurrent judges in project-by-project waves.

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -50,6 +50,46 @@ Result:
 
 - Pass
 
+## Readiness hardening proof
+
+Date: `2026-03-24`
+
+Surface:
+
+- local production logic
+- `https://vote.rajeevg.com`
+
+Commands:
+
+```bash
+pnpm exec vitest run tests/xlsx.test.ts tests/competition-logic.test.ts tests/votes.integration.test.ts tests/readiness.integration.test.ts --reporter=verbose
+pnpm exec vitest run tests/readiness.integration.test.ts --reporter=dot
+pnpm exec vitest run tests/readiness.integration.test.ts --reporter=dot
+pnpm exec vitest run tests/readiness.integration.test.ts --reporter=dot
+pnpm check
+pnpm build
+pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list
+pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 500
+```
+
+Behavior and resilience proof:
+
+- XLSX parsing/export edge cases pass
+- completion, self-vote blocking, one-vote lock, and manager tracker logic pass
+- the 50-judge readiness simulation passed in the full suite
+- the same readiness simulation then passed three consecutive standalone reruns
+- the full desktop and mobile single-screen browser flow still passed after the vote-path hardening
+- the live public-read probe passed against `vote.rajeevg.com` with `50` concurrent requests and `500` total requests, `0` failures, `p50 153.42ms`, `p95 309.21ms`, and `p99 455.01ms`
+
+Why this pass mattered:
+
+- readiness testing had surfaced intermittent `Voting is not currently open` and missing-entry failures right after round-open or entry creation under stress
+- the vote path was hardened to tolerate a short read-after-write consistency window before failing
+
+Result:
+
+- Pass
+
 ## Focused scoreboard polish proof
 
 Date: `2026-03-24`

--- a/lib/competition.ts
+++ b/lib/competition.ts
@@ -15,6 +15,7 @@ const anonymousViewer = {
   isManager: false
 } as const;
 const shouldUsePublicSnapshotCache = process.env.NODE_ENV === "production";
+const voteContextRetryDelayMs = [0, 100, 250, 500, 1000, 2000];
 
 async function ensureCompetitionState() {
   const existingState = await withPrismaRetry(() =>
@@ -91,6 +92,46 @@ async function getCompetitionSnapshotData() {
     state,
     entries
   };
+}
+
+async function resolveVoteSubmissionContext(entryId: string) {
+  let state: Awaited<ReturnType<typeof ensureCompetitionState>> | null = null;
+  let entry:
+    | Awaited<
+        ReturnType<
+          typeof prisma.entry.findUnique<{
+            where: { id: string };
+            include: { teamEmails: true };
+          }>
+        >
+      >
+    | null = null;
+
+  for (const delayMs of voteContextRetryDelayMs) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, delayMs);
+      });
+    }
+
+    [state, entry] = await Promise.all([
+      ensureCompetitionState(),
+      withPrismaRetry(() =>
+        prisma.entry.findUnique({
+          where: { id: entryId },
+          include: {
+            teamEmails: true
+          }
+        })
+      )
+    ]);
+
+    if (state.votingStatus === "OPEN" && entry) {
+      return { state, entry };
+    }
+  }
+
+  return { state, entry };
 }
 
 const getCachedPublicCompetitionSnapshot = unstable_cache(
@@ -260,19 +301,11 @@ export async function submitJudgeVote({
     throw new Error("Scores must be whole numbers from 0 to 10.");
   }
 
-  const [state, entry] = await Promise.all([
-    ensureCompetitionState(),
-    withPrismaRetry(() =>
-      prisma.entry.findUnique({
-        where: { id: entryId },
-        include: {
-          teamEmails: true
-        }
-      })
-    )
-  ]);
+  // Short retries cover pooled/remote database lag right after the manager opens the
+  // round or immediately after a workbook-driven entry set is created.
+  const { state, entry } = await resolveVoteSubmissionContext(entryId);
 
-  if (state.votingStatus !== "OPEN") {
+  if (!state || state.votingStatus !== "OPEN") {
     throw new Error("Voting is not currently open.");
   }
 

--- a/scripts/load-scoreboard.mjs
+++ b/scripts/load-scoreboard.mjs
@@ -24,6 +24,12 @@ const statusCounts = new Map();
 let completed = 0;
 let failures = 0;
 let pointer = 0;
+const scoreboardSignals = [
+  "Live hackathon scoreboard",
+  "Single-screen scoreboard",
+  "data-testid=\"scoreboard-section\"",
+  "data-testid=\"scoreboard-empty-heading\""
+];
 
 async function runOne(requestNumber) {
   const startedAt = performance.now();
@@ -38,9 +44,9 @@ async function runOne(requestNumber) {
     durations.push(elapsedMs);
     statusCounts.set(response.status, (statusCounts.get(response.status) ?? 0) + 1);
 
-    if (!body.includes("Hackathon scoreboard")) {
+    if (!scoreboardSignals.some((signal) => body.includes(signal))) {
       failures += 1;
-      console.error(`Request ${requestNumber} returned ${response.status} without the scoreboard heading.`);
+      console.error(`Request ${requestNumber} returned ${response.status} without a scoreboard signal.`);
     }
   } catch (error) {
     failures += 1;


### PR DESCRIPTION
## Links
- Closes #22

## Scope
- harden the vote path against brief read-after-write consistency lag during round-open and immediate first-vote conditions
- fix the public readiness probe so it detects the current scoreboard surface correctly
- record the stronger readiness evidence in repo docs

## Validation
- `pnpm exec vitest run tests/xlsx.test.ts tests/competition-logic.test.ts tests/votes.integration.test.ts tests/readiness.integration.test.ts --reporter=verbose`
- `pnpm exec vitest run tests/readiness.integration.test.ts --reporter=dot`
- `pnpm exec vitest run tests/readiness.integration.test.ts --reporter=dot`
- `pnpm exec vitest run tests/readiness.integration.test.ts --reporter=dot`
- `pnpm check`
- `pnpm build`
- `pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list`
- `vercel --prod --yes`
- `curl -I https://vote.rajeevg.com`
- `set -a && source .env.vercel-prod && set +a && E2E_BASE_URL=https://vote.rajeevg.com E2E_JUDGE_AUTH_MODE=ticket pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list`
- `pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 500`

## Acceptance notes
- 50-judge readiness simulation now passes reliably after the vote-path consistency hardening
- the live public-read probe now reports the real shipped scoreboard surface instead of false failures
- the latest live public-read probe passed with 0 failures, p50 153.42ms, p95 309.21ms, p99 455.01ms
- production is updated at https://vote.rajeevg.com via https://hackathon-voting-prototype-hidr834v5-rajeevgills-projects.vercel.app

## Follow-up risk
- the production proof helper still depends on a fresh pulled Clerk secret when using sign-in tickets locally; refresh `.env.vercel-prod` with `vercel env pull .env.vercel-prod --environment=production --yes` before rerunning that path.