### PR TITLE
GH-24 tighten scoreboard layout and compact vote modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Production-oriented single-screen hackathon voting app built with Next.js 14, Ty
 The app keeps the visual language of the original results dashboard, but the product has been simplified to one public scoreboard with an integrated manager control surface and a polished voting modal for judges.
 
 The current layout is intentionally content-first: the scoreboard and next action are prioritized above the fold, while explanatory rules live in lighter supporting panels instead of dominating the first scan.
-The screen stays single-column across viewports so the scoreboard leads and judging progress follows directly underneath it instead of competing in a side rail.
+The screen stays single-column across viewports so the scoreboard leads the first scan, manager controls only appear for the manager, and round state is reduced to compact status chips instead of bulky side panels.
 
 ## What the app is now
 
@@ -13,7 +13,7 @@ The screen stays single-column across viewports so the scoreboard leads and judg
 - Manager-only XLSX template download and XLSX upload
 - Authenticated judge voting in a modal
 - Automatic self-vote blocking from uploaded team-member emails
-- Live judging progress
+- Compact live status chips on the scoreboard
 - Manager-only remaining-votes tracker that mirrors the real finalization denominator
 - Table and horizontal bar-chart views on the same scoreboard
 - Manager-only per-entry voting open/closed controls
@@ -182,7 +182,7 @@ The Playwright suite covers:
 - public finalized lock state
 - manager XLSX export
 - anonymous cross-device freshness after another judge casts a score
-- single-column ordering with judging progress below the scoreboard
+- single-column ordering with no redundant setup or progress panels
 
 Cheap event-day readiness checks:
 

--- a/components/results-dashboard.tsx
+++ b/components/results-dashboard.tsx
@@ -24,64 +24,9 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { VoteDialog } from "@/components/vote-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 
-function statusCopy({
-  status,
-  isManager
-}: {
-  status: CompetitionSnapshot["status"];
-  isManager: boolean;
-}) {
-  if (!isManager) {
-    if (status === "PREPARING") {
-      return {
-        eyebrow: "Public scoreboard",
-        headline: "The field is visible now, and judging opens when the manager is ready.",
-        body: "You can follow the live rankings without signing in. Once the round opens, judges can sign in and score directly from the modal."
-      };
-    }
-
-    if (status === "OPEN") {
-      return {
-        eyebrow: "Voting live",
-        headline: "The scoreboard is the room's shared source of truth.",
-        body: "Signed-in judges can cast one locked score on each project that is still open for voting. Closed projects stay visible, but they stop taking new votes."
-      };
-    }
-
-    return {
-      eyebrow: "Finalized",
-      headline: "The final standings are locked in.",
-      body: "Judging is complete. Everyone sees the same final scoreboard, and no more votes can be added."
-    };
-  }
-
-  if (status === "PREPARING") {
-    return {
-      eyebrow: "Round control",
-      headline: "The public scoreboard is live, and judging opens when the room is ready.",
-      body: "Use the manager controls below to upload entries, close any project that should stay out of the round, and open judging only when the field is exactly right."
-    };
-  }
-
-  if (status === "OPEN") {
-    return {
-      eyebrow: "Voting live",
-      headline: "The scoreboard is the room's shared source of truth.",
-      body: "Judges can sign in and cast one locked score on each project that is still open for voting. Closed projects stay visible on the board, but they stop taking new votes."
-    };
-  }
-
-  return {
-    eyebrow: "Finalized",
-    headline: "The final standings are locked in.",
-    body: "Judging is complete. Everyone sees the same final scoreboard, and the manager can export the official results workbook."
-  };
-}
-
-function progressStateMeta(status: CompetitionSnapshot["status"]) {
+function competitionStateMeta(status: CompetitionSnapshot["status"]) {
   if (status === "PREPARING") {
     return {
       label: "Preparing",
@@ -154,11 +99,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
   const [actionMessage, setActionMessage] = React.useState<string | null>(null);
   const [authDialogOpen, setAuthDialogOpen] = React.useState(false);
   const uploadInputRef = React.useRef<HTMLInputElement>(null);
-  const copy = statusCopy({
-    status: snapshot.status,
-    isManager: snapshot.viewer.isManager
-  });
-  const stateMeta = progressStateMeta(snapshot.status);
+  const stateMeta = competitionStateMeta(snapshot.status);
   const isEmpty = snapshot.entries.length === 0;
   const scoreboardMeta = scoreboardCopy(snapshot, isEmpty);
   const autoRefreshIntervalMs = snapshot.status === "OPEN" ? 5000 : 15000;
@@ -317,45 +258,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
           </div>
         </section>
 
-        <section className="space-y-4" data-testid="workflow-summary">
-          <div className="glass-panel shell-surface rounded-[2rem] px-5 py-5 sm:px-6 sm:py-6">
-            <div className={cn("max-w-4xl", snapshot.viewer.isManager ? "" : "max-w-3xl")}>
-              <div className="eyebrow">{copy.eyebrow}</div>
-              <h1 className="mt-3 font-display text-[clamp(2rem,4vw,3.35rem)] font-black tracking-tight text-foreground">
-                Live hackathon scoreboard
-              </h1>
-              <p className="mt-3 text-base leading-8 text-foreground/90">{copy.headline}</p>
-              <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground">{copy.body}</p>
-            </div>
-
-            <div className="mt-5 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-              <span className="rounded-full bg-radix-teal-a-3 px-3 py-2 text-accent-foreground">Public board</span>
-              <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                {snapshot.progress.entryCount} entr{snapshot.progress.entryCount === 1 ? "y" : "ies"}
-              </span>
-              <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                {snapshot.progress.openEntryCount} open for voting
-              </span>
-              {snapshot.viewer.isManager && snapshot.status === "OPEN" ? (
-                <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                  {snapshot.managerTracker.totalRemainingVotes} votes left
-                </span>
-              ) : null}
-              <span
-                className={cn(
-                  "rounded-full px-3 py-2",
-                  snapshot.status === "OPEN"
-                    ? "bg-radix-teal-a-3 text-accent-foreground"
-                    : snapshot.status === "FINALIZED"
-                      ? "bg-radix-purple-a-4 text-foreground"
-                      : "bg-radix-amber-a-3 text-foreground"
-                )}
-              >
-                {stateMeta.label}
-              </span>
-            </div>
-          </div>
-
+        <section className="space-y-4">
           {snapshot.viewer.isManager ? (
             <Card className="glass-panel rounded-[2rem] border-0 bg-transparent shadow-none">
               <CardHeader className="pb-2">
@@ -570,114 +473,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                     {actionMessage}
                   </div>
                 ) : null}
-              </CardContent>
-            </Card>
-          ) : null}
 
-          <section className="space-y-3" data-testid="scoreboard-section">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-              <div className="max-w-2xl">
-                <div className="eyebrow">Scoreboard</div>
-                <h2 className="font-display text-2xl font-black">{scoreboardMeta.title}</h2>
-                <p className="mt-2 text-sm leading-7 text-muted-foreground">{scoreboardMeta.detail}</p>
-              </div>
-              <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                  {snapshot.progress.participatingJudgeCount} judging now
-                </span>
-                <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                  {snapshot.progress.openEntryCount} project{snapshot.progress.openEntryCount === 1 ? "" : "s"} open
-                </span>
-              </div>
-            </div>
-
-            <ResultsScoreboardTable
-              entries={snapshot.entries}
-              onSelectEntry={setSelectedEntry}
-              onToggleEntryVoting={snapshot.viewer.isManager ? handleEntryVotingToggle : undefined}
-              pendingEntryId={pendingEntryId}
-              status={snapshot.status}
-              viewer={snapshot.viewer}
-            />
-          </section>
-
-          <Card className="glass-panel rounded-[2rem] border-0 bg-transparent shadow-none" data-testid="progress-panel">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-base">Judging progress</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-                <div className="flex flex-wrap items-end gap-4">
-                  <div className="font-display text-5xl font-black text-primary">{snapshot.progress.percentage}%</div>
-                  <div className="pb-2 text-sm font-semibold text-muted-foreground">
-                    {snapshot.progress.castVotes}/{snapshot.progress.expectedVotes}
-                  </div>
-                </div>
-                <div className="max-w-2xl text-sm leading-7 text-muted-foreground">
-                  {snapshot.progress.helperText}
-                </div>
-              </div>
-              <Progress value={snapshot.progress.percentage} />
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                <div
-                  data-testid="progress-stat-entries"
-                  className="rounded-[1.45rem] border border-border/80 bg-radix-gray-a-3 p-4"
-                >
-                  <div className="eyebrow">Entries</div>
-                  <div
-                    data-testid="progress-stat-entries-value"
-                    className="mt-3 font-display text-[1.85rem] font-black leading-[1] tracking-tight"
-                  >
-                    {snapshot.progress.entryCount}
-                  </div>
-                  <p className="mt-3 text-xs leading-5 text-muted-foreground">Projects currently shown on the board.</p>
-                </div>
-                <div className="rounded-[1.45rem] border border-border/80 bg-radix-gray-a-3 p-4">
-                  <div className="eyebrow">Open now</div>
-                  <div className="mt-3 font-display text-[1.85rem] font-black leading-[1] tracking-tight">
-                    {snapshot.progress.openEntryCount}
-                  </div>
-                  <p className="mt-3 text-xs leading-5 text-muted-foreground">
-                    Only open projects accept new votes and count toward completion.
-                  </p>
-                </div>
-                <div
-                  data-testid="progress-stat-judges"
-                  className="rounded-[1.45rem] border border-border/80 bg-radix-gray-a-3 p-4"
-                >
-                  <div className="eyebrow">Judges in round</div>
-                  <div
-                    data-testid="progress-stat-judges-value"
-                    className="mt-3 font-display text-[1.85rem] font-black leading-[1] tracking-tight"
-                  >
-                    {snapshot.progress.participatingJudgeCount}
-                  </div>
-                  <p className="mt-3 text-xs leading-5 text-muted-foreground">
-                    The denominator only counts judges who have already started scoring.
-                  </p>
-                </div>
-                <div
-                  data-testid="progress-stat-state"
-                  className={cn(
-                    "rounded-[1.45rem] border p-4",
-                    stateMeta.accentClassName
-                  )}
-                >
-                  <div className="eyebrow">State</div>
-                  <div
-                    data-testid="progress-stat-state-value"
-                    className="mt-3 font-display text-[1.85rem] font-black leading-[1.02] tracking-tight"
-                  >
-                    {stateMeta.label}
-                  </div>
-                  <p className="mt-3 text-xs leading-5 opacity-90">{stateMeta.detail}</p>
-                </div>
-              </div>
-              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                Board refreshes automatically every {Math.round(autoRefreshIntervalMs / 1000)} seconds while this tab is active.
-              </div>
-
-              {snapshot.viewer.isManager ? (
                 <div
                   className="rounded-[1.7rem] border border-border/80 bg-radix-gray-a-3/70 p-4 sm:p-5"
                   data-testid="manager-remaining-votes"
@@ -781,9 +577,74 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                     </div>
                   )}
                 </div>
-              ) : null}
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          <section className="space-y-3" data-testid="scoreboard-section">
+            <div className="glass-panel rounded-[2rem] px-5 py-5 sm:px-6">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                <div className="max-w-3xl">
+                  <div className="eyebrow">
+                    {snapshot.viewer.isManager ? "Manager view" : "Public scoreboard"}
+                  </div>
+                  <h1 className="mt-2 font-display text-[clamp(1.8rem,3.8vw,2.8rem)] font-black tracking-tight">
+                    Live hackathon scoreboard
+                  </h1>
+                  <p className="mt-3 text-sm leading-7 text-muted-foreground">{scoreboardMeta.detail}</p>
+                </div>
+                <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                  <span className="rounded-full bg-radix-teal-a-3 px-3 py-2 text-accent-foreground">Public board</span>
+                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                    {snapshot.progress.entryCount} entr{snapshot.progress.entryCount === 1 ? "y" : "ies"}
+                  </span>
+                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                    {snapshot.progress.openEntryCount} open now
+                  </span>
+                  {snapshot.status === "OPEN" ? (
+                    <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                      {snapshot.progress.participatingJudgeCount} judging now
+                    </span>
+                  ) : null}
+                  {snapshot.viewer.isManager && snapshot.status === "OPEN" ? (
+                    <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                      {snapshot.managerTracker.totalRemainingVotes} votes left
+                    </span>
+                  ) : null}
+                  <span
+                    className={cn(
+                      "rounded-full px-3 py-2",
+                      snapshot.status === "OPEN"
+                        ? "bg-radix-teal-a-3 text-accent-foreground"
+                        : snapshot.status === "FINALIZED"
+                          ? "bg-radix-purple-a-4 text-foreground"
+                          : "bg-radix-amber-a-3 text-foreground"
+                    )}
+                    data-testid="competition-state-badge"
+                  >
+                    {stateMeta.label}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="max-w-2xl">
+                <div className="eyebrow">Scoreboard</div>
+                <h2 className="font-display text-2xl font-black">{scoreboardMeta.title}</h2>
+                <p className="mt-2 text-sm leading-7 text-muted-foreground">{scoreboardMeta.detail}</p>
+              </div>
+            </div>
+
+            <ResultsScoreboardTable
+              entries={snapshot.entries}
+              onSelectEntry={setSelectedEntry}
+              onToggleEntryVoting={snapshot.viewer.isManager ? handleEntryVotingToggle : undefined}
+              pendingEntryId={pendingEntryId}
+              status={snapshot.status}
+              viewer={snapshot.viewer}
+            />
+          </section>
         </section>
       </main>
 

--- a/components/vote-dialog.tsx
+++ b/components/vote-dialog.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
-import {
-  ArrowRight,
-  CheckCircle2,
-  LockKeyhole,
-  Sparkles
-} from "lucide-react";
+import { ArrowRight, CheckCircle2, LockKeyhole } from "lucide-react";
 import * as React from "react";
 
 import { JudgeAuthPanel } from "@/components/judge-auth-panel";
@@ -14,7 +9,6 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog";
@@ -119,75 +113,51 @@ export function VoteDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[min(96vw,58rem)] overflow-hidden border-border/90 p-0">
-        <div className="shell-surface relative max-h-[88vh] overflow-y-auto px-4 py-4 sm:px-6 sm:py-5">
-          <div className="absolute inset-x-0 top-0 h-24 bg-[radial-gradient(circle_at_top_left,var(--hero-glow),transparent_72%)]" />
-          <div className="relative space-y-4">
-            <DialogHeader className="space-y-2">
+      <DialogContent className="w-[min(94vw,44rem)] overflow-hidden border-border/90 p-0">
+        <div className="shell-surface relative max-h-[88vh] overflow-y-auto px-4 py-4 sm:px-5 sm:py-4">
+          <div className="absolute inset-x-0 top-0 h-20 bg-[radial-gradient(circle_at_top_left,var(--hero-glow),transparent_72%)]" />
+          <div className="relative space-y-3">
+            <DialogHeader className="space-y-1.5">
               <div className="eyebrow">Judge vote</div>
-              <DialogTitle className="max-w-3xl text-[clamp(1.85rem,3vw,2.55rem)] leading-[0.95]">
+              <DialogTitle className="max-w-3xl text-[clamp(1.5rem,2.7vw,2.1rem)] leading-[0.98]">
                 {entry.projectName}
               </DialogTitle>
-              <DialogDescription className="max-w-3xl text-sm leading-6">
-                {entry.summary ??
-                  "Capture the energy of the project in one clear score from 0 to 10. Judges get one decisive vote per project, so everything here is designed to be fast and obvious."}
-              </DialogDescription>
+              {entry.summary ? (
+                <p className="max-w-3xl text-sm leading-6 text-muted-foreground">{entry.summary}</p>
+              ) : null}
             </DialogHeader>
 
-            <div className="grid gap-3 lg:grid-cols-[1.05fr_0.95fr]">
-              <div className="rounded-[1.5rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4">
-                <div className="flex flex-wrap items-center gap-2">
-                  {entry.teamName ? (
-                    <span className="rounded-full bg-radix-gray-a-3 px-3 py-1 text-xs font-semibold text-muted-foreground">
-                      {entry.teamName}
-                    </span>
-                  ) : null}
-                  <span className="rounded-full bg-radix-teal-a-3 px-3 py-1 text-xs font-semibold text-accent-foreground">
-                    {entry.voteCount} submitted vote{entry.voteCount === 1 ? "" : "s"}
+            <div className="rounded-[1.35rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] px-3.5 py-3">
+              <div className="flex flex-wrap items-center gap-2">
+                {entry.teamName ? (
+                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-1 text-xs font-semibold text-muted-foreground">
+                    {entry.teamName}
                   </span>
-                  <span
-                    className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${
-                      isEntryClosed ? "bg-radix-amber-a-3 text-foreground" : "bg-radix-gray-a-3 text-muted-foreground"
-                    }`}
-                  >
-                    {isEntryClosed ? "Voting paused" : "Voting active"}
+                ) : null}
+                <span className="rounded-full bg-radix-teal-a-3 px-3 py-1 text-xs font-semibold text-accent-foreground">
+                  {entry.voteCount} submitted vote{entry.voteCount === 1 ? "" : "s"}
+                </span>
+                <span
+                  className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${
+                    isEntryClosed ? "bg-radix-amber-a-3 text-foreground" : "bg-radix-gray-a-3 text-muted-foreground"
+                  }`}
+                >
+                  {isEntryClosed ? "Voting paused" : "Voting active"}
+                </span>
+                <span className="rounded-full bg-radix-gray-a-3 px-3 py-1 text-xs font-semibold text-muted-foreground">
+                  Total{" "}
+                  <span className="font-display text-sm font-black text-foreground" data-testid="vote-dialog-aggregate-total">
+                    {entry.totalScore}
                   </span>
-                </div>
-
-                <div className="mt-4 flex items-end justify-between gap-4">
-                  <div>
-                    <div className="eyebrow">Live aggregate</div>
-                    <div
-                      className="mt-2 font-display text-4xl font-black text-primary sm:text-5xl"
-                      data-testid="vote-dialog-aggregate-total"
-                    >
-                      {entry.totalScore}
-                    </div>
-                  </div>
-                  <div
-                    className="max-w-[15rem] text-right text-sm leading-6 text-muted-foreground"
-                    data-testid="vote-dialog-aggregate-summary"
-                  >
-                    {entry.averageScore == null
-                      ? "No average yet"
-                      : `${entry.averageScore} average across ${entry.voteCount} vote${entry.voteCount === 1 ? "" : "s"}`}
-                  </div>
-                </div>
-              </div>
-
-              <div className="rounded-[1.5rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4">
-                <div className="flex items-center gap-2 text-sm font-semibold text-muted-foreground">
-                  <Sparkles className="h-4 w-4 text-primary" />
-                  <span>Keyboard friendly and optimized for quick judging.</span>
-                </div>
-                <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.16em]">
-                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-1.5 text-muted-foreground">0-3 Stretch</span>
-                  <span className="rounded-full bg-radix-purple-a-4 px-3 py-1.5 text-foreground">4-7 Strong</span>
-                  <span className="rounded-full bg-radix-teal-a-4 px-3 py-1.5 text-accent-foreground">8-10 Winner</span>
-                </div>
-                <p className="mt-4 text-sm leading-6 text-muted-foreground">
-                  Choose the number that matches your conviction. Once you submit, that vote locks for the rest of the round.
-                </p>
+                </span>
+                <span
+                  className="rounded-full bg-radix-gray-a-3 px-3 py-1 text-xs font-semibold text-muted-foreground"
+                  data-testid="vote-dialog-aggregate-summary"
+                >
+                  {entry.averageScore == null
+                    ? "No average yet"
+                    : `${entry.averageScore} avg`}
+                </span>
               </div>
             </div>
 
@@ -229,7 +199,7 @@ export function VoteDialog({
             ) : null}
 
             {isLocked ? (
-              <div className="glass-panel rounded-[1.7rem] p-5 sm:p-6">
+              <div className="glass-panel rounded-[1.55rem] p-4 sm:p-5">
                 <h3 className="font-display text-2xl font-black">
                   {status === "PREPARING" ? "Voting opens soon" : "Judging is finalized"}
                 </h3>
@@ -240,7 +210,7 @@ export function VoteDialog({
                 </p>
               </div>
             ) : hasRecordedVote ? (
-              <div className="glass-panel rounded-[1.7rem] p-5 sm:p-6">
+              <div className="glass-panel rounded-[1.55rem] p-4 sm:p-5">
                 <div className="eyebrow">Vote locked</div>
                 <h3 className="mt-2 font-display text-2xl font-black">Score recorded</h3>
                 <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
@@ -248,14 +218,14 @@ export function VoteDialog({
                 </p>
               </div>
             ) : isEntryClosed ? (
-              <div className="glass-panel rounded-[1.7rem] p-5 sm:p-6">
+              <div className="glass-panel rounded-[1.55rem] p-4 sm:p-5">
                 <h3 className="font-display text-2xl font-black">Voting is paused</h3>
                 <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
                   This project is still visible on the public board, but the manager has closed it to new votes for now.
                 </p>
               </div>
             ) : needsAuth ? (
-              <div className="glass-panel rounded-[1.7rem] p-5 sm:p-6">
+              <div className="glass-panel rounded-[1.55rem] p-4 sm:p-5">
                 <JudgeAuthPanel
                   afterAuthenticate={() => {
                     onVoteSaved();
@@ -265,40 +235,40 @@ export function VoteDialog({
                 />
               </div>
             ) : isBlocked ? (
-              <div className="glass-panel rounded-[1.7rem] p-5 sm:p-6">
+              <div className="glass-panel rounded-[1.55rem] p-4 sm:p-5">
                 <h3 className="font-display text-2xl font-black">You can’t score this one</h3>
                 <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
                   We block self-voting automatically so judges never need to second-guess whether a score is allowed.
                 </p>
               </div>
             ) : (
-              <div className="glass-panel rounded-[1.7rem] p-4 sm:p-5" data-testid="vote-dialog-fit-surface">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="glass-panel rounded-[1.55rem] p-3.5 sm:p-4" data-testid="vote-dialog-fit-surface">
+                <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
                   <div>
                     <div className="eyebrow">Cast your only vote</div>
-                    <h3 className="mt-2 font-display text-2xl font-black sm:text-[2rem]">Make it count</h3>
+                    <h3 className="mt-1.5 font-display text-[1.65rem] font-black sm:text-[1.85rem]">Make it count</h3>
                   </div>
-                  <div className="inline-flex items-center rounded-full bg-radix-gray-a-3 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                  <div className="inline-flex items-center rounded-full bg-radix-gray-a-3 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                     No edits after submit
                   </div>
                 </div>
 
-                <div className="mt-4 rounded-[1.4rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4">
+                <div className="mt-3 rounded-[1.25rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-3">
                   <div className="flex flex-wrap items-end justify-between gap-3">
                     <div>
                       <div className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                         Selected score
                       </div>
-                      <div className="mt-2 flex items-end gap-3">
-                        <div className="font-display text-5xl font-black text-primary sm:text-6xl">{previewScore}</div>
-                        <div className="pb-1">
-                          <div className="text-base font-semibold text-foreground">{preview.band}</div>
-                          <div className="max-w-xs text-sm leading-6 text-muted-foreground">{preview.summary}</div>
+                      <div className="mt-1.5 flex items-end gap-3">
+                        <div className="font-display text-4xl font-black text-primary sm:text-5xl">{previewScore}</div>
+                        <div className="pb-0.5">
+                          <div className="text-sm font-semibold text-foreground">{preview.band}</div>
+                          <div className="max-w-[15rem] text-xs leading-5 text-muted-foreground">{preview.summary}</div>
                         </div>
                       </div>
                     </div>
                     <div
-                      className={`rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] ${preview.accentClassName}`}
+                      className={`rounded-full px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.16em] ${preview.accentClassName}`}
                     >
                       {preview.band}
                     </div>
@@ -306,7 +276,7 @@ export function VoteDialog({
                 </div>
 
                 <RadioGroup
-                  className="mt-4 grid grid-cols-4 gap-2 sm:grid-cols-6"
+                  className="mt-3 grid grid-cols-4 gap-2 sm:grid-cols-6"
                   value={selectedScore}
                   onValueChange={setSelectedScore}
                 >
@@ -319,12 +289,12 @@ export function VoteDialog({
                         autoFocus={value === 7}
                         key={value}
                         value={String(value)}
-                        className="group relative flex min-h-[64px] flex-col items-start justify-between overflow-hidden rounded-[1.25rem] border-border/80 bg-[rgb(255_255_255_/_0.03)] px-3 py-2.5 text-left hover:-translate-y-0.5 data-[state=checked]:shadow-[0_18px_50px_var(--shadow-soft)] sm:min-h-[72px]"
+                        className="group relative flex min-h-[54px] flex-col items-start justify-between overflow-hidden rounded-[1.05rem] border-border/80 bg-[rgb(255_255_255_/_0.03)] px-2.5 py-2 text-left hover:-translate-y-0.5 data-[state=checked]:shadow-[0_18px_50px_var(--shadow-soft)] sm:min-h-[58px]"
                         data-testid={`score-option-${value}`}
                       >
                         <span className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-transparent via-radix-teal-a-6 to-transparent opacity-0 transition group-data-[state=checked]:opacity-100" />
-                        <span className="font-display text-[1.6rem] font-black leading-none sm:text-[1.8rem]">{value}</span>
-                        <span className="text-[0.58rem] font-semibold uppercase tracking-[0.2em] text-muted-foreground group-data-[state=checked]:text-accent-foreground">
+                        <span className="font-display text-[1.35rem] font-black leading-none sm:text-[1.5rem]">{value}</span>
+                        <span className="text-[0.52rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground group-data-[state=checked]:text-accent-foreground">
                           {tone.band}
                         </span>
                       </RadioGroupItem>
@@ -332,35 +302,31 @@ export function VoteDialog({
                   })}
                 </RadioGroup>
 
-                <p className="mt-3 text-sm leading-6 text-muted-foreground">
-                  Tab into the score grid, then use arrow keys and press space or enter to choose.
-                </p>
-
-                <div className="mt-4">
+                <div className="mt-3">
                   <AnimatePresence mode="wait">
                     {state === "success" ? (
                       <motion.div
                         key="vote-success"
                         animate={{ opacity: 1, y: 0 }}
                         aria-live="polite"
-                        className="rounded-[1.45rem] border border-radix-teal-a-6 bg-radix-teal-a-3 p-4 text-accent-foreground shadow-halo"
+                        className="rounded-[1.25rem] border border-radix-teal-a-6 bg-radix-teal-a-3 p-3.5 text-accent-foreground shadow-halo"
                         data-testid="vote-saved-toast"
                         exit={{ opacity: 0, y: 10 }}
                         initial={{ opacity: 0, y: 14 }}
                         role="status"
                       >
                         <div className="flex items-start gap-3">
-                          <div className="mt-1 rounded-full bg-[rgb(255_255_255_/_0.14)] p-2">
-                            <CheckCircle2 className="h-5 w-5" />
+                          <div className="mt-0.5 rounded-full bg-[rgb(255_255_255_/_0.14)] p-1.5">
+                            <CheckCircle2 className="h-4.5 w-4.5" />
                           </div>
                           <div>
-                            <div className="text-sm font-semibold uppercase tracking-[0.18em]">
+                            <div className="text-[0.7rem] font-semibold uppercase tracking-[0.18em]">
                               Vote locked in
                             </div>
-                            <div className="mt-1 font-display text-2xl font-black">
+                            <div className="mt-1 font-display text-xl font-black sm:text-2xl">
                               {previewScore} points recorded
                             </div>
-                            <div className="mt-1 text-sm leading-6">
+                            <div className="mt-1 text-sm leading-5">
                               Your score is live on the board now. This project is locked for the rest of the round.
                             </div>
                           </div>
@@ -370,26 +336,23 @@ export function VoteDialog({
                       <motion.div
                         key="vote-cta"
                         animate={{ opacity: 1, y: 0 }}
-                        className="rounded-[1.45rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-4"
+                        className="rounded-[1.25rem] border border-border/80 bg-[rgb(255_255_255_/_0.03)] p-3.5"
                         exit={{ opacity: 0, y: 10 }}
                         initial={{ opacity: 0, y: 14 }}
                       >
                         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                           <div className="min-w-0">
-                            <div className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                              Ready to submit
-                            </div>
-                            <div className="mt-1 text-sm leading-6 text-muted-foreground">
-                              You are about to lock{" "}
+                            <div className="text-sm leading-5 text-muted-foreground">
+                              Lock{" "}
                               <span className="font-semibold text-foreground">{previewScore}</span> for this project.
                             </div>
                           </div>
                           <Button
-                            className="min-w-[200px] justify-center"
+                            className="min-w-[172px] justify-center"
                             data-testid="submit-vote"
                             disabled={!selectedScore || state === "submitting"}
                             onClick={submitVote}
-                            size="lg"
+                            size="sm"
                           >
                             {state === "submitting" ? (
                               "Locking vote..."

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -16,7 +16,7 @@ The app is intentionally a single-screen product.
 ### Public viewer
 
 - No auth required.
-- Can see the scoreboard, judging progress, and finalized state.
+- Can see the scoreboard and finalized or live round state.
 - Cannot upload, begin voting, finalize, or vote.
 
 ### Manager

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -37,8 +37,8 @@ Flows proven:
 - Manager finalizes the round
 - Manager downloads the finalized XLSX export
 - Public finalized state is visible and modal voting is locked
-- The judging-progress state card keeps its label fully contained at mobile and wide desktop widths
-- The scoreboard remains visually ahead of the progress section, and the progress section stays below the board across breakpoints
+- The scoreboard remains the dominant first-read surface after the redundant manager-summary and judging-progress panels were removed
+- The compact vote modal fits above the fold on both proof viewports without redundant instructional blocks
 
 Artifacts:
 
@@ -96,7 +96,7 @@ Date: `2026-03-24`
 
 Goal:
 
-- Re-check the single-column ordering after removing the old side rail and ensure progress stays below the scoreboard cleanly
+- Re-check the single-column ordering after removing the old side rail and keeping the scoreboard as the dominant first-read surface
 
 Local production surface:
 
@@ -115,10 +115,10 @@ Focused proof artifacts:
 
 Observed result:
 
-- The state card now renders `Preparing` instead of the raw uppercase enum token.
-- Mobile at `430px` keeps the progress cards readable without clipping or overlap.
+- The state badge now renders `Preparing` instead of the raw uppercase enum token.
+- Mobile at `430px` keeps the scoreboard header and first board section readable without clipping or overlap.
 - Wide desktop at `1575px` keeps the scoreboard dominant instead of splitting attention with a side rail.
-- DOM measurement on both local production and the live site confirmed the state label stayed inset inside its card with healthy top and bottom space.
+- DOM measurement on both local production and the live site confirmed the compact state badge stayed within the viewport with no overflow.
 
 Result:
 
@@ -130,7 +130,7 @@ Date: `2026-03-24`
 
 Goal:
 
-- Prove the single-column scoreboard keeps the board above the progress section and stays contained at the in-between widths where the live site previously clipped
+- Prove the single-column scoreboard stays contained at the in-between widths where the live site previously clipped
 
 Local validation:
 
@@ -148,9 +148,8 @@ Viewports covered:
 Proof contract:
 
 - No horizontal page overflow
-- Progress panel appears below the scoreboard section
-- State card remains inside the viewport
-- State label keeps healthy top and bottom inset inside the card
+- No redundant summary or progress panel remains on the page
+- State badge remains inside the viewport
 - Mid-width layouts keep the one-column reading order without accidental side-by-side competition
 
 Artifacts:
@@ -289,7 +288,7 @@ Design proof notes:
 - Desktop uses the full width well without horizontal overflow
 - Mobile layout preserves the single-screen journey and keeps the modal legible and tappable
 - The modal remains the visual center of the flow on both viewports while fitting above the fold in the judge proof run
-- The judging-progress state card now uses a friendly label plus helper copy, and fresh section proof confirmed no clipping or overlap in the status area
+- The page no longer exposes redundant `Round control` or `Judging progress` panels; state is carried by compact chips and manager-only tracker surfaces instead
 
 Artifacts:
 

--- a/tests/e2e/scoreboard-breakpoints.spec.ts
+++ b/tests/e2e/scoreboard-breakpoints.spec.ts
@@ -12,7 +12,7 @@ test.describe("single-column scoreboard stays coherent across breakpoints", () =
   test.skip(!runLayoutProof, "Run this focused breakpoint proof only when explicitly requested.");
 
   for (const viewport of viewports) {
-    test(`${viewport.name} keeps the scoreboard and progress flow coherent`, async ({ page }, testInfo) => {
+    test(`${viewport.name} keeps the scoreboard flow coherent`, async ({ page }, testInfo) => {
       if (testInfo.project.name === "desktop-light" && viewport.name === "mobile-tight") {
         test.skip(true, "Mobile-tight layout is covered by the dedicated mobile project.");
       }
@@ -32,7 +32,10 @@ test.describe("single-column scoreboard stays coherent across breakpoints", () =
       await page.goto("/");
       const appOrigin = new URL(page.url()).origin;
 
-      await expect(page.getByTestId("workflow-summary")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Live hackathon scoreboard" })).toBeVisible();
+      await expect(page.getByTestId("competition-state-badge")).toBeVisible();
+      await expect(page.getByTestId("progress-panel")).toHaveCount(0);
+      await expect(page.getByTestId("workflow-summary")).toHaveCount(0);
 
       const pageMetrics = await page.evaluate(() => ({
         viewportWidth: window.innerWidth,
@@ -44,35 +47,22 @@ test.describe("single-column scoreboard stays coherent across breakpoints", () =
       const scoreboardTop = await page.locator("[data-testid='scoreboard-section']").evaluate((element) => {
         return element.getBoundingClientRect().top;
       });
-      const progressTop = await page.locator("[data-testid='progress-panel']").evaluate((element) => {
-        return element.getBoundingClientRect().top;
-      });
 
       expect(scoreboardTop).toBeLessThan(viewport.height * 0.82);
-      expect(progressTop).toBeGreaterThan(scoreboardTop);
 
-      const stateMetrics = await page.locator("[data-testid='progress-stat-state']").evaluate((element) => {
+      const stateBadgeMetrics = await page.locator("[data-testid='competition-state-badge']").evaluate((element) => {
         const rect = element.getBoundingClientRect();
-        const value = element.querySelector<HTMLElement>("[data-testid='progress-stat-state-value']");
-        const valueRect = value?.getBoundingClientRect();
-
         return {
-          cardLeft: rect.left,
-          cardRight: rect.right,
+          left: rect.left,
+          right: rect.right,
           viewportWidth: window.innerWidth,
-          valueText: value?.textContent?.trim() ?? "",
-          valueTopInset: valueRect ? valueRect.top - rect.top : null,
-          valueBottomInset: valueRect ? rect.bottom - valueRect.bottom : null
+          text: element.textContent?.trim() ?? ""
         };
       });
 
-      expect(stateMetrics.cardLeft).toBeGreaterThanOrEqual(0);
-      expect(stateMetrics.cardRight).toBeLessThanOrEqual(stateMetrics.viewportWidth);
-      expect(stateMetrics.valueText.length).toBeGreaterThan(0);
-      expect(stateMetrics.valueTopInset).not.toBeNull();
-      expect(stateMetrics.valueBottomInset).not.toBeNull();
-      expect(stateMetrics.valueTopInset!).toBeGreaterThan(10);
-      expect(stateMetrics.valueBottomInset!).toBeGreaterThan(10);
+      expect(stateBadgeMetrics.left).toBeGreaterThanOrEqual(0);
+      expect(stateBadgeMetrics.right).toBeLessThanOrEqual(stateBadgeMetrics.viewportWidth);
+      expect(stateBadgeMetrics.text.length).toBeGreaterThan(0);
 
       await page.screenshot({ path: testInfo.outputPath(`${viewport.name}.png`), fullPage: true });
       expect(serverErrors.filter((entry) => entry.includes(appOrigin))).toEqual([]);

--- a/tests/e2e/single-screen-voting.spec.ts
+++ b/tests/e2e/single-screen-voting.spec.ts
@@ -222,32 +222,10 @@ async function takeShot(page: Page, outputPath: string) {
   });
 }
 
-async function expectProgressStateCardToContainValue(page: Page, expectedText: string) {
-  const card = page.getByTestId("progress-stat-state");
-  const value = page.getByTestId("progress-stat-state-value");
-
-  await expect(card).toBeVisible();
-  await expect(value).toHaveText(expectedText);
-
-  const measurements = await card.evaluate((element) => {
-    const valueElement = element.querySelector<HTMLElement>("[data-testid='progress-stat-state-value']");
-    if (!valueElement) return null;
-
-    const cardRect = element.getBoundingClientRect();
-    const valueRect = valueElement.getBoundingClientRect();
-
-    return {
-      topInset: valueRect.top - cardRect.top,
-      bottomInset: cardRect.bottom - valueRect.bottom,
-      valueHeight: valueRect.height,
-      cardHeight: cardRect.height
-    };
-  });
-
-  expect(measurements).not.toBeNull();
-  expect(measurements!.topInset).toBeGreaterThan(10);
-  expect(measurements!.bottomInset).toBeGreaterThan(10);
-  expect(measurements!.valueHeight).toBeLessThan(measurements!.cardHeight - 20);
+async function expectCompetitionStateBadge(page: Page, expectedText: string) {
+  const badge = page.getByTestId("competition-state-badge");
+  await expect(badge).toBeVisible();
+  await expect(badge).toHaveText(expectedText);
 }
 
 test.beforeEach(async ({ baseURL }, testInfo) => {
@@ -282,7 +260,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await anonymousPage.goto("/");
     await expect(anonymousPage.getByRole("heading", { name: "Live hackathon scoreboard" })).toBeVisible();
     await expect(anonymousPage.getByTestId("scoreboard-empty-heading")).toBeVisible();
-    await expectProgressStateCardToContainValue(anonymousPage, "Preparing");
+    await expectCompetitionStateBadge(anonymousPage, "Preparing");
     await expect(anonymousPage.getByText("Manager setup")).toHaveCount(0);
     await expect(anonymousPage.getByText("Manager controls")).toHaveCount(0);
     await expect(anonymousPage.getByTestId("manager-download-template")).toHaveCount(0);
@@ -328,7 +306,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
     await takeShot(managerPage, testInfo.outputPath("manager-after-upload.png"));
 
     await managerPage.getByTestId("manager-begin-voting").click();
-    await expect(managerPage.getByTestId("progress-stat-state-value")).toHaveText("Voting live");
+    await expectCompetitionStateBadge(managerPage, "Voting live");
 
     await managerPage
       .getByTestId("manager-entry-toggle-harbor-pulse")
@@ -454,12 +432,9 @@ test("manager, judges, and public users complete the single-screen voting flow",
 
   await test.step("Progress reaches completion and the manager finalizes the round", async () => {
     await managerPage.goto("/");
-    await expect(managerPage.getByText("5/5")).toBeVisible();
-    await expect(
-      managerPage.getByText(
-        "Every participating judge has scored every project that is still open for them. The manager can finalize the results."
-      )
-    ).toBeVisible();
+    await expect(managerPage.getByText("Everyone who joined the round is fully covered.")).toBeVisible();
+    await expect(managerPage.getByTestId("manager-remaining-votes")).toContainText("Votes left");
+    await expect(managerPage.getByTestId("manager-finalize")).toBeEnabled();
 
     const hasHorizontalOverflow = await managerPage.evaluate(
       () => document.documentElement.scrollWidth > window.innerWidth + 1
@@ -467,7 +442,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
     expect(hasHorizontalOverflow).toBe(false);
 
     await managerPage.getByTestId("manager-finalize").click();
-    await expect(managerPage.getByTestId("progress-stat-state-value")).toHaveText("Finalized");
+    await expectCompetitionStateBadge(managerPage, "Finalized");
 
     const [exportDownload] = await Promise.all([
       managerPage.waitForEvent("download"),
@@ -480,7 +455,7 @@ test("manager, judges, and public users complete the single-screen voting flow",
 
   await test.step("Public users see the finalized board and locked modal state", async () => {
     await anonymousPage.goto("/");
-    await expect(anonymousPage.getByTestId("progress-stat-state-value")).toHaveText("Finalized");
+    await expectCompetitionStateBadge(anonymousPage, "Finalized");
     await openVoteDialog(anonymousPage, "Signal Bloom");
     await expect(anonymousPage.getByRole("heading", { name: "Judging is finalized" })).toBeVisible();
     await expect(


### PR DESCRIPTION
## Summary
- remove the redundant round-control and judging-progress panels and keep the screen single-column
- move the manager remaining-votes tracker into the manager controls surface
- compact the vote modal so the voting action fits above the fold and remove redundant helper copy

## Validation
- pnpm check
- pnpm build
- E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list
- LAYOUT_PROOF=1 pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
- vercel --prod --yes
- curl -I https://vote.rajeevg.com
- set -a && source .env.vercel-prod && set +a && E2E_BASE_URL=https://vote.rajeevg.com E2E_JUDGE_AUTH_MODE=ticket pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list
- LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compact status chips now display competition state on the scoreboard, replacing large progress panels.
  * Manager-only vote tracking displays when the round is open.

* **Style**
  * Restructured dashboard layout with clearer distinction between manager and public views.
  * Simplified voting dialog with streamlined aggregate score display.

* **Documentation**
  * Updated user guides to reflect new compact status display and simplified layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->