### PR TITLE
GH-28 remove scoreboard hero and go straight to board

### DIFF
--- a/components/results-dashboard.tsx
+++ b/components/results-dashboard.tsx
@@ -582,53 +582,42 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
           ) : null}
 
           <section className="space-y-3" data-testid="scoreboard-section">
-            <div className="glass-panel rounded-[2rem] px-5 py-5 sm:px-6">
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-                <div className="max-w-3xl">
-                  <h1 className="mt-2 font-display text-[clamp(1.8rem,3.8vw,2.8rem)] font-black tracking-tight">
-                    Live hackathon scoreboard
-                  </h1>
-                  <p className="mt-3 text-sm leading-7 text-muted-foreground">{scoreboardMeta.detail}</p>
-                </div>
-                <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                    {snapshot.progress.entryCount} entr{snapshot.progress.entryCount === 1 ? "y" : "ies"}
-                  </span>
-                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                    {snapshot.progress.openEntryCount} open now
-                  </span>
-                  {snapshot.status === "OPEN" ? (
-                    <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                      {snapshot.progress.participatingJudgeCount} judging now
-                    </span>
-                  ) : null}
-                  {snapshot.viewer.isManager && snapshot.status === "OPEN" ? (
-                    <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                      {snapshot.managerTracker.totalRemainingVotes} votes left
-                    </span>
-                  ) : null}
-                  <span
-                    className={cn(
-                      "rounded-full px-3 py-2",
-                      snapshot.status === "OPEN"
-                        ? "bg-radix-teal-a-3 text-accent-foreground"
-                        : snapshot.status === "FINALIZED"
-                          ? "bg-radix-purple-a-4 text-foreground"
-                          : "bg-radix-amber-a-3 text-foreground"
-                    )}
-                    data-testid="competition-state-badge"
-                  >
-                    {stateMeta.label}
-                  </span>
-                </div>
-              </div>
-            </div>
-
             <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
               <div className="max-w-2xl">
                 <div className="eyebrow">Scoreboard</div>
-                <h2 className="font-display text-2xl font-black">{scoreboardMeta.title}</h2>
+                <h1 className="font-display text-2xl font-black">{scoreboardMeta.title}</h1>
                 <p className="mt-2 text-sm leading-7 text-muted-foreground">{scoreboardMeta.detail}</p>
+              </div>
+              <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                  {snapshot.progress.entryCount} entr{snapshot.progress.entryCount === 1 ? "y" : "ies"}
+                </span>
+                <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                  {snapshot.progress.openEntryCount} open now
+                </span>
+                {snapshot.status === "OPEN" ? (
+                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                    {snapshot.progress.participatingJudgeCount} judging now
+                  </span>
+                ) : null}
+                {snapshot.viewer.isManager && snapshot.status === "OPEN" ? (
+                  <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                    {snapshot.managerTracker.totalRemainingVotes} votes left
+                  </span>
+                ) : null}
+                <span
+                  className={cn(
+                    "rounded-full px-3 py-2",
+                    snapshot.status === "OPEN"
+                      ? "bg-radix-teal-a-3 text-accent-foreground"
+                      : snapshot.status === "FINALIZED"
+                        ? "bg-radix-purple-a-4 text-foreground"
+                        : "bg-radix-amber-a-3 text-foreground"
+                  )}
+                  data-testid="competition-state-badge"
+                >
+                  {stateMeta.label}
+                </span>
               </div>
             </div>
 

--- a/tests/e2e/scoreboard-breakpoints.spec.ts
+++ b/tests/e2e/scoreboard-breakpoints.spec.ts
@@ -32,7 +32,7 @@ test.describe("single-column scoreboard stays coherent across breakpoints", () =
       await page.goto("/");
       const appOrigin = new URL(page.url()).origin;
 
-      await expect(page.getByRole("heading", { name: "Live hackathon scoreboard" })).toBeVisible();
+      await expect(page.getByTestId("scoreboard-section")).toBeVisible();
       await expect(page.getByTestId("competition-state-badge")).toBeVisible();
       await expect(page.getByTestId("progress-panel")).toHaveCount(0);
       await expect(page.getByTestId("workflow-summary")).toHaveCount(0);

--- a/tests/e2e/single-screen-voting.spec.ts
+++ b/tests/e2e/single-screen-voting.spec.ts
@@ -258,7 +258,6 @@ test("manager, judges, and public users complete the single-screen voting flow",
 
   await test.step("Anonymous visitors can see the board but not manager tools", async () => {
     await anonymousPage.goto("/");
-    await expect(anonymousPage.getByRole("heading", { name: "Live hackathon scoreboard" })).toBeVisible();
     await expect(anonymousPage.getByTestId("scoreboard-empty-heading")).toBeVisible();
     await expectCompetitionStateBadge(anonymousPage, "Preparing");
     await expect(anonymousPage.getByText("Manager setup")).toHaveCount(0);


### PR DESCRIPTION
## Summary
- remove the extra scoreboard hero block entirely
- make the page go directly from the top header/nav into the real scoreboard section
- tighten the proof to target the scoreboard section and empty state directly

## Validation
- pnpm check
- LAYOUT_PROOF=1 pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
- E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list
- vercel --prod --yes
- curl -I https://vote.rajeevg.com
- LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Refactored the scoreboard header layout for improved visual organization. The badge row showing entry counts, open-now status, judging state, and competition status is now inlined with the title section.

* **Tests**
  * Updated E2E tests to reflect scoreboard header restructuring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->