### PR TITLE
gh-30 tighten mobile scoreboard density

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The app keeps the visual language of the original results dashboard, but the pro
 
 The current layout is intentionally content-first: the scoreboard and next action are prioritized above the fold, while explanatory rules live in lighter supporting panels instead of dominating the first scan.
 The screen stays single-column across viewports so the scoreboard leads the first scan, manager controls only appear for the manager, and round state is reduced to compact status chips instead of bulky side panels.
+On mobile, the secondary scoreboard summary and board-view controls stay collapsed by default and expand as overlays, so the table itself remains visible sooner.
 
 ## What the app is now
 
@@ -197,6 +198,7 @@ These checks prove two different things:
 - `readiness:public` sends 250 public scoreboard requests with 50-way concurrency to confirm the live site stays responsive under the expected spectator load without requiring a paid load-testing service.
 
 Proof notes live in [proof.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/proof.md).
+Viewport-specific appearance and usability findings live in [viewport-ux-audit.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/viewport-ux-audit.md).
 
 ## Auth and deploy notes
 

--- a/components/results-dashboard.tsx
+++ b/components/results-dashboard.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import * as React from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import {
   ArrowUpRight,
+  ChevronDown,
   FileSpreadsheet,
   Flag,
   FolderUp,
+  Info,
   LoaderCircle,
   Play,
   RotateCcw,
@@ -98,7 +101,9 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
   const [isDragOver, setIsDragOver] = React.useState(false);
   const [actionMessage, setActionMessage] = React.useState<string | null>(null);
   const [authDialogOpen, setAuthDialogOpen] = React.useState(false);
+  const [mobileSummaryOpen, setMobileSummaryOpen] = React.useState(false);
   const uploadInputRef = React.useRef<HTMLInputElement>(null);
+  const mobileSummaryRef = React.useRef<HTMLDivElement>(null);
   const stateMeta = competitionStateMeta(snapshot.status);
   const isEmpty = snapshot.entries.length === 0;
   const scoreboardMeta = scoreboardCopy(snapshot, isEmpty);
@@ -115,6 +120,19 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
     if (!hasPendingJudgeAuthVerification()) return;
     setAuthDialogOpen(true);
   }, [snapshot.viewer.isAuthenticated]);
+
+  React.useEffect(() => {
+    if (!mobileSummaryOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!mobileSummaryRef.current?.contains(event.target as Node)) {
+        setMobileSummaryOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [mobileSummaryOpen]);
 
   function refreshBoard() {
     startTransition(() => {
@@ -581,8 +599,82 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
             </Card>
           ) : null}
 
-          <section className="space-y-3" data-testid="scoreboard-section">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <section className="relative space-y-3" data-testid="scoreboard-section">
+            <div className="md:hidden" ref={mobileSummaryRef}>
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="eyebrow">Scoreboard</div>
+                  <h1 className="font-display text-2xl font-black" data-testid="scoreboard-primary-heading">
+                    {scoreboardMeta.title}
+                  </h1>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "rounded-full px-3 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.18em]",
+                      snapshot.status === "OPEN"
+                        ? "bg-radix-teal-a-3 text-accent-foreground"
+                        : snapshot.status === "FINALIZED"
+                          ? "bg-radix-purple-a-4 text-foreground"
+                          : "bg-radix-amber-a-3 text-foreground"
+                    )}
+                    data-testid="competition-state-badge"
+                  >
+                    {stateMeta.label}
+                  </span>
+                  {!isEmpty ? (
+                    <Button
+                      className="shrink-0"
+                      data-testid="scoreboard-mobile-summary-toggle"
+                      onClick={() => setMobileSummaryOpen((open) => !open)}
+                      size="sm"
+                      type="button"
+                      variant="outline"
+                    >
+                      <Info className="h-4 w-4" />
+                      Details
+                      <ChevronDown
+                        className={cn("h-4 w-4 transition", mobileSummaryOpen ? "rotate-180" : "")}
+                      />
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+
+              <AnimatePresence>
+                {mobileSummaryOpen ? (
+                  <motion.div
+                    animate={{ opacity: 1, y: 0, scale: 1 }}
+                    className="absolute inset-x-0 top-full z-30 mt-3 rounded-[1.5rem] border border-border/80 bg-background/95 p-4 shadow-[0_20px_70px_var(--shadow-soft)] backdrop-blur"
+                    data-testid="scoreboard-mobile-summary-panel"
+                    exit={{ opacity: 0, y: -8, scale: 0.98 }}
+                    initial={{ opacity: 0, y: -8, scale: 0.98 }}
+                  >
+                    <p className="text-sm leading-6 text-muted-foreground">{scoreboardMeta.detail}</p>
+                    <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                        {snapshot.progress.entryCount} entr{snapshot.progress.entryCount === 1 ? "y" : "ies"}
+                      </span>
+                      <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                        {snapshot.progress.openEntryCount} open now
+                      </span>
+                      {snapshot.status === "OPEN" ? (
+                        <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                          {snapshot.progress.participatingJudgeCount} judging now
+                        </span>
+                      ) : null}
+                      {snapshot.viewer.isManager && snapshot.status === "OPEN" ? (
+                        <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                          {snapshot.managerTracker.totalRemainingVotes} votes left
+                        </span>
+                      ) : null}
+                    </div>
+                  </motion.div>
+                ) : null}
+              </AnimatePresence>
+            </div>
+
+            <div className="hidden flex-col gap-3 lg:flex-row lg:items-end lg:justify-between md:flex">
               <div className="max-w-2xl">
                 <div className="eyebrow">Scoreboard</div>
                 <h1 className="font-display text-2xl font-black">{scoreboardMeta.title}</h1>

--- a/components/results-scoreboard-table.tsx
+++ b/components/results-scoreboard-table.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { BarChart3, Lock, PauseCircle, PlayCircle, Table2, Vote } from "lucide-react";
+import { BarChart3, ChevronDown, Lock, PauseCircle, PlayCircle, Table2, Vote } from "lucide-react";
 
 import type { ScoreboardEntryView, ViewerIdentity } from "@/lib/competition-logic";
 import { Button } from "@/components/ui/button";
@@ -231,7 +231,22 @@ export function ResultsScoreboardTable({
   pendingEntryId
 }: ResultsScoreboardTableProps) {
   const [viewMode, setViewMode] = React.useState<"table" | "chart">("table");
+  const [mobileViewPanelOpen, setMobileViewPanelOpen] = React.useState(false);
+  const mobileViewPanelRef = React.useRef<HTMLDivElement>(null);
   const showManagerControls = viewer.isManager;
+
+  React.useEffect(() => {
+    if (!mobileViewPanelOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!mobileViewPanelRef.current?.contains(event.target as Node)) {
+        setMobileViewPanelOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [mobileViewPanelOpen]);
 
   if (entries.length === 0) {
     return (
@@ -256,8 +271,79 @@ export function ResultsScoreboardTable({
   }
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col gap-3 rounded-[1.7rem] border border-border/70 bg-radix-gray-a-2/65 p-3 sm:flex-row sm:items-center sm:justify-between sm:p-4">
+    <div className="relative space-y-4">
+      <div className="md:hidden" ref={mobileViewPanelRef}>
+        <div className="flex items-center justify-between rounded-[1.35rem] border border-border/70 bg-radix-gray-a-2/65 px-3 py-2.5">
+          <div>
+            <div className="text-sm font-semibold text-foreground">Board view</div>
+            <div className="text-xs text-muted-foreground">
+              {viewMode === "table" ? "Ranked table active" : "Horizontal bar chart active"}
+            </div>
+          </div>
+          <Button
+            data-testid="scoreboard-mobile-view-toggle"
+            onClick={() => setMobileViewPanelOpen((open) => !open)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {viewMode === "table" ? <Table2 className="h-4 w-4" /> : <BarChart3 className="h-4 w-4" />}
+            {viewMode === "table" ? "Table" : "Bar chart"}
+            <ChevronDown className={cn("h-4 w-4 transition", mobileViewPanelOpen ? "rotate-180" : "")} />
+          </Button>
+        </div>
+
+        <AnimatePresence>
+          {mobileViewPanelOpen ? (
+            <motion.div
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              className="absolute inset-x-0 top-full z-30 mt-3 rounded-[1.5rem] border border-border/80 bg-background/95 p-4 shadow-[0_20px_70px_var(--shadow-soft)] backdrop-blur"
+              data-testid="scoreboard-mobile-view-panel"
+              exit={{ opacity: 0, y: -8, scale: 0.98 }}
+              initial={{ opacity: 0, y: -8, scale: 0.98 }}
+            >
+              <div className="text-sm font-semibold text-foreground">Choose how the board reads</div>
+              <div className="mt-1 text-sm text-muted-foreground">
+                Switch between the ranked table and the horizontal bar chart without losing your place.
+              </div>
+              <div className="mt-4 inline-flex w-full rounded-full bg-radix-gray-a-3 p-1">
+                <button
+                  className={cn(
+                    "inline-flex flex-1 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition",
+                    viewMode === "table" ? "bg-background text-foreground shadow-soft" : "text-muted-foreground"
+                  )}
+                  data-testid="scoreboard-view-table"
+                  onClick={() => {
+                    setViewMode("table");
+                    setMobileViewPanelOpen(false);
+                  }}
+                  type="button"
+                >
+                  <Table2 className="h-4 w-4" />
+                  Table
+                </button>
+                <button
+                  className={cn(
+                    "inline-flex flex-1 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition",
+                    viewMode === "chart" ? "bg-background text-foreground shadow-soft" : "text-muted-foreground"
+                  )}
+                  data-testid="scoreboard-view-chart"
+                  onClick={() => {
+                    setViewMode("chart");
+                    setMobileViewPanelOpen(false);
+                  }}
+                  type="button"
+                >
+                  <BarChart3 className="h-4 w-4" />
+                  Bar chart
+                </button>
+              </div>
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </div>
+
+      <div className="hidden flex-col gap-3 rounded-[1.7rem] border border-border/70 bg-radix-gray-a-2/65 p-3 sm:flex-row sm:items-center sm:justify-between sm:p-4 md:flex">
         <div className="min-w-0">
           <div className="text-sm font-semibold text-foreground">Board view</div>
           <div className="text-sm text-muted-foreground">

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -227,6 +227,68 @@ Production artifacts:
 - `artifacts/layout-proof/prod-mid.png`
 - `artifacts/layout-proof/prod-mobile.png`
 
+Result:
+
+- Pass
+
+## Mobile density and viewport audit
+
+Date: `2026-03-24`
+
+Goal:
+
+- keep the scoreboard visible sooner on mobile by collapsing secondary summary and board-view surfaces by default
+- ensure those supporting panels expand as overlays instead of pushing the scoreboard down the page
+- re-audit the visual hierarchy across mobile, mid-width, tablet, and desktop
+
+Local validation:
+
+```bash
+pnpm check
+pnpm build
+E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --project=desktop-light --reporter=list
+E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --project=mobile-dark --reporter=list
+LAYOUT_PROOF=1 E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
+```
+
+Production validation:
+
+```bash
+curl -I https://vote.rajeevg.com
+E2E_BASE_URL=https://vote.rajeevg.com E2E_JUDGE_AUTH_MODE=ticket pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list
+LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
+```
+
+What the proof checked:
+
+- mobile summary and board-view panels are collapsed by default
+- the mobile controls can still be opened and used
+- the first scoreboard row remains visible sooner in the mobile first scan
+- the same single-column hierarchy holds through mid-width, tablet, and wide desktop
+- manager, judge, and public journeys still complete on production after the density change
+
+Audit artifacts:
+
+- `artifacts/ux-audit/gh-30/prod-mobile-public.png`
+- `artifacts/ux-audit/gh-30/prod-mid-public.png`
+- `artifacts/ux-audit/gh-30/local-tablet-public.png`
+- `artifacts/ux-audit/gh-30/prod-wide-desktop-public.png`
+
+Audit note:
+
+- `docs/viewport-ux-audit.md`
+
+Observed result:
+
+- mobile now defers secondary scoreboard chrome until requested, which lifts the board higher without hiding functionality
+- opened supporting panels overlay the page instead of reflowing the scoreboard downward
+- mid-width, tablet, and desktop retain the simplified single-column reading order
+- production desktop and mobile end-to-end flows remained green after the change
+
+Result:
+
+- Pass
+
 ## Event-day readiness proof
 
 Date: `2026-03-23`

--- a/docs/viewport-ux-audit.md
+++ b/docs/viewport-ux-audit.md
@@ -1,0 +1,145 @@
+# Viewport UX Audit
+
+Date: `2026-03-24`
+
+Scope:
+
+- public scoreboard layout
+- mobile density and above-the-fold priority
+- board-view controls
+- scoreboard header copy and chips
+- cross-viewport visual rhythm
+- vote-flow usability re-check via fresh Playwright proof
+
+Method:
+
+- heuristic review using content-priority, scanability, disclosure, and reachability checks
+- fresh local and production Playwright runs after the mobile-density change
+- screenshot review across mobile, mid-width, tablet, and wide desktop
+
+## What changed
+
+The mobile scoreboard now treats supporting chrome as secondary. On small screens:
+
+- the scoreboard summary details start collapsed
+- the board-view switcher starts collapsed
+- opening either surface uses an overlay panel instead of pushing the table farther down
+- the first scoreboard row stays visible sooner in the initial scan
+
+## Screenshots reviewed
+
+- `artifacts/ux-audit/gh-30/prod-mobile-public.png`
+- `artifacts/ux-audit/gh-30/prod-mid-public.png`
+- `artifacts/ux-audit/gh-30/local-tablet-public.png`
+- `artifacts/ux-audit/gh-30/prod-wide-desktop-public.png`
+
+## Viewport findings
+
+### Mobile
+
+Verdict:
+
+- Pass
+
+What is working:
+
+- header/nav stays compact enough that the scoreboard heading and first row arrive much earlier
+- supporting board metadata is hidden by default, which reduces pre-scroll cognitive load
+- the board-view control no longer burns a full card above the table when the user has not asked for it
+- the scoreboard remains readable in the first scan without sacrificing access to detail
+
+Why it is safer:
+
+- the supporting sections use progressive disclosure instead of permanent vertical space
+- those panels open over the UI rather than reflowing the table downward, so the board position stays predictable
+
+### Mid-width
+
+Verdict:
+
+- Pass
+
+What is working:
+
+- the single-column reading order holds
+- the scoreboard intro and controls feel intentional instead of stretched
+- chips, heading, and table/chart controls have enough breathing room without creating a dead zone
+
+### Tablet
+
+Verdict:
+
+- Pass
+
+What is working:
+
+- the layout still reads top-to-bottom without accidental competition between panels
+- the scoreboard remains the dominant block
+- spacing is calmer than mobile while preserving the same mental model
+
+### Wide desktop
+
+Verdict:
+
+- Pass
+
+What is working:
+
+- the page no longer spends its strongest real estate on explanatory support copy
+- the scoreboard section stays visually dominant
+- supporting status information is compact and subordinate
+
+## Usability audit summary
+
+### Information hierarchy
+
+- Pass
+- The app now puts the board ahead of explanatory chrome on every viewport.
+
+### Progressive disclosure
+
+- Pass
+- Small screens hide optional detail until the user asks for it.
+
+### Task continuity
+
+- Pass
+- Opening summary or board-view detail does not shove the scoreboard down the page.
+
+### Cognitive load
+
+- Pass
+- Users see fewer choices before reaching the board, especially on mobile.
+
+### Consistency
+
+- Pass
+- The same single-column hierarchy now survives from mobile through desktop.
+
+### Reachability
+
+- Pass
+- Fresh Playwright proof confirmed the collapsed sections can still be opened, used, and dismissed, and the scoreboard remains usable afterward.
+
+## Residual risk
+
+- The mobile experience is materially better, but long project names or unusually large team names can still increase row height and make the first visible row denser than the proof fixture. That is a normal content-variance risk, not a structural layout failure.
+
+## Validation used for this audit
+
+```bash
+pnpm check
+pnpm build
+E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --project=desktop-light --reporter=list
+E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --project=mobile-dark --reporter=list
+LAYOUT_PROOF=1 E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
+curl -I https://vote.rajeevg.com
+E2E_BASE_URL=https://vote.rajeevg.com E2E_JUDGE_AUTH_MODE=ticket pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list
+LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
+```
+
+## Overall verdict
+
+- Pass
+
+The mobile-first density change did what it needed to do: it restored the scoreboard as the first meaningful destination on small screens without hiding useful controls or breaking the desktop experience.

--- a/tests/e2e/scoreboard-breakpoints.spec.ts
+++ b/tests/e2e/scoreboard-breakpoints.spec.ts
@@ -33,7 +33,7 @@ test.describe("single-column scoreboard stays coherent across breakpoints", () =
       const appOrigin = new URL(page.url()).origin;
 
       await expect(page.getByTestId("scoreboard-section")).toBeVisible();
-      await expect(page.getByTestId("competition-state-badge")).toBeVisible();
+      await expect(page.locator('[data-testid="competition-state-badge"]:visible').first()).toBeVisible();
       await expect(page.getByTestId("progress-panel")).toHaveCount(0);
       await expect(page.getByTestId("workflow-summary")).toHaveCount(0);
 
@@ -50,7 +50,7 @@ test.describe("single-column scoreboard stays coherent across breakpoints", () =
 
       expect(scoreboardTop).toBeLessThan(viewport.height * 0.82);
 
-      const stateBadgeMetrics = await page.locator("[data-testid='competition-state-badge']").evaluate((element) => {
+      const stateBadgeMetrics = await page.locator("[data-testid='competition-state-badge']:visible").first().evaluate((element) => {
         const rect = element.getBoundingClientRect();
         return {
           left: rect.left,

--- a/tests/e2e/single-screen-voting.spec.ts
+++ b/tests/e2e/single-screen-voting.spec.ts
@@ -223,9 +223,15 @@ async function takeShot(page: Page, outputPath: string) {
 }
 
 async function expectCompetitionStateBadge(page: Page, expectedText: string) {
-  const badge = page.getByTestId("competition-state-badge");
+  const badge = page.locator('[data-testid="competition-state-badge"]:visible').first();
   await expect(badge).toBeVisible();
   await expect(badge).toHaveText(expectedText);
+}
+
+async function firstScoreboardRowTop(page: Page, slug: string) {
+  return page.getByTestId(`scoreboard-row-${slug}`).first().evaluate((element) => {
+    return element.getBoundingClientRect().top;
+  });
 }
 
 test.beforeEach(async ({ baseURL }, testInfo) => {
@@ -293,10 +299,32 @@ test("manager, judges, and public users complete the single-screen voting flow",
       "Harbor Collective Reloaded"
     );
 
-    await managerPage.getByTestId("scoreboard-view-chart").click();
+    if (testInfo.project.name.includes("mobile")) {
+      await expect(managerPage.getByTestId("scoreboard-mobile-summary-panel")).toHaveCount(0);
+      await expect(managerPage.getByTestId("scoreboard-mobile-view-panel")).toHaveCount(0);
+
+      await managerPage.getByTestId("scoreboard-mobile-summary-toggle").click();
+      await expect(managerPage.getByTestId("scoreboard-mobile-summary-panel")).toBeVisible();
+      await managerPage.getByTestId("scoreboard-mobile-summary-toggle").click();
+      await expect(managerPage.getByTestId("scoreboard-mobile-summary-panel")).toHaveCount(0);
+
+      await managerPage.getByTestId("scoreboard-mobile-view-toggle").click();
+      await expect(managerPage.getByTestId("scoreboard-mobile-view-panel")).toBeVisible();
+    }
+
+    if (testInfo.project.name.includes("mobile")) {
+      await managerPage.getByTestId("scoreboard-mobile-view-panel").getByTestId("scoreboard-view-chart").click();
+    } else {
+      await managerPage.getByTestId("scoreboard-view-chart").click();
+    }
     await expect(managerPage.getByTestId("scoreboard-chart-view")).toBeVisible();
     await takeShot(managerPage, testInfo.outputPath("manager-chart-view.png"));
-    await managerPage.getByTestId("scoreboard-view-table").click();
+    if (testInfo.project.name.includes("mobile")) {
+      await managerPage.getByTestId("scoreboard-mobile-view-toggle").click();
+      await managerPage.getByTestId("scoreboard-mobile-view-panel").getByTestId("scoreboard-view-table").click();
+    } else {
+      await managerPage.getByTestId("scoreboard-view-table").click();
+    }
     if (testInfo.project.name.includes("mobile")) {
       await expect(managerPage.getByTestId("scoreboard-row-aurora-atlas").nth(rowIndex)).toBeVisible();
     } else {
@@ -321,6 +349,13 @@ test("manager, judges, and public users complete the single-screen voting flow",
 
   await test.step("Anonymous users stay read-only after voting opens", async () => {
     await anonymousPage.goto("/");
+    if (testInfo.project.name.includes("mobile")) {
+      await expect(anonymousPage.getByTestId("scoreboard-mobile-summary-panel")).toHaveCount(0);
+      await expect(anonymousPage.getByTestId("scoreboard-mobile-view-panel")).toHaveCount(0);
+      const firstRowTop = await firstScoreboardRowTop(anonymousPage, "aurora-atlas");
+      const viewportHeight = await anonymousPage.evaluate(() => window.innerHeight);
+      expect(firstRowTop).toBeLessThan(viewportHeight - 120);
+    }
     await openVoteDialog(anonymousPage, "Harbor Pulse");
     await expect(anonymousPage.getByText("Voting is paused for this project right now.")).toBeVisible();
     await expect(anonymousPage.getByTestId("submit-vote")).toHaveCount(0);


### PR DESCRIPTION
## Summary\n- collapse the mobile scoreboard summary and board-view surfaces by default\n- open those mobile surfaces as overlays so the board stays visible sooner\n- add viewport audit notes and fresh desktop/mobile proof coverage\n\n## Why\nThe mobile scoreboard was still hiding too much of the actual board beneath supporting chrome, which made the first scan feel wasteful and weakened confidence in the layout.\n\n## Validation\n- pnpm check\n- pnpm build\n- E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --project=desktop-light --reporter=list\n- E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --project=mobile-dark --reporter=list\n- LAYOUT_PROOF=1 E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list\n- curl -I https://vote.rajeevg.com\n- E2E_BASE_URL=https://vote.rajeevg.com E2E_JUDGE_AUTH_MODE=ticket pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list\n- LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list\n\nCloses #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mobile scoreboard now collapses secondary panels (summary details and board-view controls) by default, expanding as overlays to keep the main table visible sooner.

* **Documentation**
  * Added viewport UX audit documentation with validation findings across mobile, tablet, and desktop device sizes.

* **Tests**
  * Updated tests to verify mobile-specific panel behavior and confirm scoreboard row visibility on small screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->