### PR TITLE
gh-37: remove floating privacy settings button

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -123,9 +123,9 @@ export default function PrivacyPage() {
           <div className="space-y-2">
             <h2 className="text-xl font-semibold text-foreground">6. Your choices</h2>
             <p>
-              You can reopen privacy settings at any time from the app footer or the floating privacy
-              button and switch between necessary-only and analytics-enabled measurement. You can also
-              clear relevant cookies and local storage in your browser.
+              You can reopen privacy settings at any time from the app footer and switch between
+              necessary-only and analytics-enabled measurement. You can also clear relevant cookies
+              and local storage in your browser.
             </p>
           </div>
         </div>

--- a/components/consent-manager.tsx
+++ b/components/consent-manager.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { ConsentPreferencesButton } from "@/components/consent-preferences-button";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardTitle } from "@/components/ui/card";
 import { beginAnalyticsPageView, getPageAnalyticsContext, pushDataLayerEvent } from "@/lib/analytics";
@@ -108,8 +107,6 @@ export function ConsentManager() {
 
   if (!analyticsEnabled) return null;
 
-  const shouldShowPreferencesButton = consentState && consentState.source !== "default";
-
   return (
     <>
       {isBannerOpen ? (
@@ -152,22 +149,6 @@ export function ConsentManager() {
               </div>
             </CardContent>
           </Card>
-        </div>
-      ) : null}
-
-      {shouldShowPreferencesButton ? (
-        <div className="fixed bottom-6 right-6 z-40 max-md:hidden">
-          <ConsentPreferencesButton
-            aria-label="Privacy settings"
-            className="shadow-sm"
-            data-analytics-event="consent_preferences_reopen"
-            data-analytics-item-name="Privacy settings"
-            data-analytics-item-type="consent_preferences_button"
-            data-analytics-section="floating_privacy_button"
-            size="sm"
-            title="Privacy settings"
-            variant="secondary"
-          />
         </div>
       ) : null}
     </>

--- a/tests/e2e/scoreboard-breakpoints.spec.ts
+++ b/tests/e2e/scoreboard-breakpoints.spec.ts
@@ -36,6 +36,7 @@ test.describe("single-column scoreboard stays coherent across breakpoints", () =
       await expect(page.locator('[data-testid="competition-state-badge"]:visible').first()).toBeVisible();
       await expect(page.getByTestId("progress-panel")).toHaveCount(0);
       await expect(page.getByTestId("workflow-summary")).toHaveCount(0);
+      await expect(page.locator('[data-analytics-section="floating_privacy_button"]')).toHaveCount(0);
 
       const pageMetrics = await page.evaluate(() => ({
         viewportWidth: window.innerWidth,


### PR DESCRIPTION
## Summary
- remove the duplicate floating privacy settings button from the app shell
- keep the footer privacy controls as the only re-entry path
- add a focused breakpoint regression check so the floating affordance does not come back

## Validation
- pnpm check
- pnpm build
- curl -I http://localhost:3017
- LAYOUT_PROOF=1 E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
- vercel --prod --yes
- curl -I https://vote.rajeevg.com
- curl -s https://vote.rajeevg.com | rg -n "Privacy policy|Privacy settings|floating_privacy_button"
- LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the floating "Privacy settings" button previously displayed in the lower-right corner of pages

* **Documentation**
  * Updated privacy policy to accurately describe how users can manage consent preferences, including switching between measurement modes and managing cookies and local storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->