### PR TITLE
gh-39: harden mobile scoreboard disclosures

### DIFF
--- a/components/results-dashboard.tsx
+++ b/components/results-dashboard.tsx
@@ -24,6 +24,7 @@ import { JudgeAuthDialog } from "@/components/judge-auth-dialog";
 import { hasPendingJudgeAuthVerification } from "@/components/judge-auth-panel";
 import { ResultsScoreboardTable } from "@/components/results-scoreboard-table";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { VoteDialog } from "@/components/vote-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -104,7 +105,6 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
   const [authDialogOpen, setAuthDialogOpen] = React.useState(false);
   const [mobileSummaryOpen, setMobileSummaryOpen] = React.useState(false);
   const uploadInputRef = React.useRef<HTMLInputElement>(null);
-  const mobileSummaryRef = React.useRef<HTMLDivElement>(null);
   const stateMeta = competitionStateMeta(snapshot.status);
   const isEmpty = snapshot.entries.length === 0;
   const scoreboardMeta = scoreboardCopy(snapshot, isEmpty);
@@ -148,19 +148,6 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
   React.useEffect(() => {
     pushDataLayerEvent("competition_state_snapshot", analyticsContext);
   }, [analyticsContext]);
-
-  React.useEffect(() => {
-    if (!mobileSummaryOpen) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (!mobileSummaryRef.current?.contains(event.target as Node)) {
-        setMobileSummaryOpen(false);
-      }
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    return () => document.removeEventListener("pointerdown", handlePointerDown);
-  }, [mobileSummaryOpen]);
 
   function refreshBoard() {
     startTransition(() => {
@@ -291,6 +278,15 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
     uploadInputRef.current?.click();
   }
 
+  function handleMobileSummaryOpenChange(nextOpen: boolean) {
+    pushDataLayerEvent("scoreboard_summary_toggled", {
+      summary_state: nextOpen ? "open" : "closed",
+      trigger_surface: "mobile",
+      ...analyticsContext
+    });
+    setMobileSummaryOpen(nextOpen);
+  }
+
   return (
     <div className="min-h-screen">
       <main className="container space-y-5 py-6 sm:space-y-6 sm:py-8">
@@ -344,6 +340,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
             <Card
               className="glass-panel rounded-[2rem] border-0 bg-transparent shadow-none"
               data-analytics-section="manager_controls"
+              data-testid="manager-controls"
             >
               <CardHeader className="pb-2">
                 <CardTitle className="text-base">Manager controls</CardTitle>
@@ -690,7 +687,7 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
             data-analytics-section="scoreboard"
             data-testid="scoreboard-section"
           >
-            <div className="md:hidden" ref={mobileSummaryRef}>
+            <div className="md:hidden">
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <div className="eyebrow">Scoreboard</div>
@@ -714,17 +711,11 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                   </span>
                   {!isEmpty ? (
                     <Button
+                      aria-expanded={mobileSummaryOpen}
+                      aria-haspopup="dialog"
                       className="shrink-0"
                       data-testid="scoreboard-mobile-summary-toggle"
-                      onClick={() => {
-                        const nextOpen = !mobileSummaryOpen;
-                        pushDataLayerEvent("scoreboard_summary_toggled", {
-                          summary_state: nextOpen ? "open" : "closed",
-                          trigger_surface: "mobile",
-                          ...analyticsContext
-                        });
-                        setMobileSummaryOpen(nextOpen);
-                      }}
+                      onClick={() => handleMobileSummaryOpenChange(true)}
                       size="sm"
                       type="button"
                       variant="outline"
@@ -739,38 +730,39 @@ export function ResultsDashboard({ snapshot }: { snapshot: CompetitionSnapshot }
                 </div>
               </div>
 
-              <AnimatePresence>
-                {mobileSummaryOpen ? (
-                  <motion.div
-                    animate={{ opacity: 1, y: 0, scale: 1 }}
-                    className="absolute inset-x-0 top-full z-30 mt-3 rounded-[1.5rem] border border-border/80 bg-background/95 p-4 shadow-[0_20px_70px_var(--shadow-soft)] backdrop-blur"
-                    data-testid="scoreboard-mobile-summary-panel"
-                    exit={{ opacity: 0, y: -8, scale: 0.98 }}
-                    initial={{ opacity: 0, y: -8, scale: 0.98 }}
-                  >
-                    <p className="text-sm leading-6 text-muted-foreground">{scoreboardMeta.detail}</p>
-                    <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                      <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                        {snapshot.progress.entryCount} entr{snapshot.progress.entryCount === 1 ? "y" : "ies"}
-                      </span>
-                      <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                        {snapshot.progress.openEntryCount} open now
-                      </span>
-                      {snapshot.status === "OPEN" ? (
-                        <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                          {snapshot.progress.participatingJudgeCount} judging now
-                        </span>
-                      ) : null}
-                      {snapshot.viewer.isManager && snapshot.status === "OPEN" ? (
-                        <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
-                          {snapshot.managerTracker.totalRemainingVotes} votes left
-                        </span>
-                      ) : null}
-                    </div>
-                  </motion.div>
-                ) : null}
-              </AnimatePresence>
             </div>
+
+            <Dialog onOpenChange={handleMobileSummaryOpenChange} open={mobileSummaryOpen}>
+              <DialogContent
+                className="bottom-0 left-0 right-0 top-auto max-h-[85vh] w-full max-w-none translate-x-0 translate-y-0 overflow-y-auto rounded-b-none rounded-t-[1.75rem] border-x-0 border-b-0 p-0"
+                data-testid="scoreboard-mobile-summary-panel"
+              >
+                <div className="shell-surface px-5 pb-6 pt-5">
+                  <DialogHeader className="pr-10">
+                    <DialogTitle className="text-xl">Scoreboard details</DialogTitle>
+                    <DialogDescription>{scoreboardMeta.detail}</DialogDescription>
+                  </DialogHeader>
+                  <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                      {snapshot.progress.entryCount} entr{snapshot.progress.entryCount === 1 ? "y" : "ies"}
+                    </span>
+                    <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                      {snapshot.progress.openEntryCount} open now
+                    </span>
+                    {snapshot.status === "OPEN" ? (
+                      <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                        {snapshot.progress.participatingJudgeCount} judging now
+                      </span>
+                    ) : null}
+                    {snapshot.viewer.isManager && snapshot.status === "OPEN" ? (
+                      <span className="rounded-full bg-radix-gray-a-3 px-3 py-2">
+                        {snapshot.managerTracker.totalRemainingVotes} votes left
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              </DialogContent>
+            </Dialog>
 
             <div className="hidden flex-col gap-3 lg:flex-row lg:items-end lg:justify-between md:flex">
               <div className="max-w-2xl">

--- a/components/results-scoreboard-table.tsx
+++ b/components/results-scoreboard-table.tsx
@@ -6,6 +6,7 @@ import { BarChart3, ChevronDown, Lock, PauseCircle, PlayCircle, Table2, Vote } f
 
 import type { ScoreboardEntryView, ViewerIdentity } from "@/lib/competition-logic";
 import { pushDataLayerEvent } from "@/lib/analytics";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -233,21 +234,7 @@ export function ResultsScoreboardTable({
 }: ResultsScoreboardTableProps) {
   const [viewMode, setViewMode] = React.useState<"table" | "chart">("table");
   const [mobileViewPanelOpen, setMobileViewPanelOpen] = React.useState(false);
-  const mobileViewPanelRef = React.useRef<HTMLDivElement>(null);
   const showManagerControls = viewer.isManager;
-
-  React.useEffect(() => {
-    if (!mobileViewPanelOpen) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (!mobileViewPanelRef.current?.contains(event.target as Node)) {
-        setMobileViewPanelOpen(false);
-      }
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    return () => document.removeEventListener("pointerdown", handlePointerDown);
-  }, [mobileViewPanelOpen]);
 
   function handleViewModeChange(nextViewMode: "table" | "chart", triggerSurface: "mobile" | "desktop") {
     setViewMode(nextViewMode);
@@ -283,7 +270,7 @@ export function ResultsScoreboardTable({
 
   return (
     <div className="relative space-y-4">
-      <div className="md:hidden" ref={mobileViewPanelRef}>
+      <div className="md:hidden">
         <div className="flex items-center justify-between rounded-[1.35rem] border border-border/70 bg-radix-gray-a-2/65 px-3 py-2.5">
           <div>
             <div className="text-sm font-semibold text-foreground">Board view</div>
@@ -292,8 +279,10 @@ export function ResultsScoreboardTable({
             </div>
           </div>
           <Button
+            aria-expanded={mobileViewPanelOpen}
+            aria-haspopup="dialog"
             data-testid="scoreboard-mobile-view-toggle"
-            onClick={() => setMobileViewPanelOpen((open) => !open)}
+            onClick={() => setMobileViewPanelOpen(true)}
             size="sm"
             type="button"
             variant="outline"
@@ -304,55 +293,55 @@ export function ResultsScoreboardTable({
           </Button>
         </div>
 
-        <AnimatePresence>
-          {mobileViewPanelOpen ? (
-            <motion.div
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              className="absolute inset-x-0 top-full z-30 mt-3 rounded-[1.5rem] border border-border/80 bg-background/95 p-4 shadow-[0_20px_70px_var(--shadow-soft)] backdrop-blur"
-              data-testid="scoreboard-mobile-view-panel"
-              exit={{ opacity: 0, y: -8, scale: 0.98 }}
-              initial={{ opacity: 0, y: -8, scale: 0.98 }}
-            >
-              <div className="text-sm font-semibold text-foreground">Choose how the board reads</div>
-              <div className="mt-1 text-sm text-muted-foreground">
-                Switch between the ranked table and the horizontal bar chart without losing your place.
-              </div>
-              <div className="mt-4 inline-flex w-full rounded-full bg-radix-gray-a-3 p-1">
-                <button
-                  className={cn(
-                    "inline-flex flex-1 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition",
-                    viewMode === "table" ? "bg-background text-foreground shadow-soft" : "text-muted-foreground"
-                  )}
-                  data-testid="scoreboard-view-table"
-                  onClick={() => {
-                    handleViewModeChange("table", "mobile");
-                    setMobileViewPanelOpen(false);
-                  }}
-                  type="button"
-                >
-                  <Table2 className="h-4 w-4" />
-                  Table
-                </button>
-                <button
-                  className={cn(
-                    "inline-flex flex-1 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition",
-                    viewMode === "chart" ? "bg-background text-foreground shadow-soft" : "text-muted-foreground"
-                  )}
-                  data-testid="scoreboard-view-chart"
-                  onClick={() => {
-                    handleViewModeChange("chart", "mobile");
-                    setMobileViewPanelOpen(false);
-                  }}
-                  type="button"
-                >
-                  <BarChart3 className="h-4 w-4" />
-                  Bar chart
-                </button>
-              </div>
-            </motion.div>
-          ) : null}
-        </AnimatePresence>
       </div>
+
+      <Dialog onOpenChange={setMobileViewPanelOpen} open={mobileViewPanelOpen}>
+        <DialogContent
+          className="bottom-0 left-0 right-0 top-auto max-h-[85vh] w-full max-w-none translate-x-0 translate-y-0 overflow-y-auto rounded-b-none rounded-t-[1.75rem] border-x-0 border-b-0 p-0 md:hidden"
+          data-testid="scoreboard-mobile-view-panel"
+        >
+          <div className="shell-surface px-5 pb-6 pt-5">
+            <DialogHeader className="pr-10">
+              <DialogTitle className="text-xl">Choose board view</DialogTitle>
+              <DialogDescription>
+                Switch between the ranked table and the horizontal bar chart without losing your place.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-4 inline-flex w-full rounded-full bg-radix-gray-a-3 p-1">
+              <button
+                className={cn(
+                  "inline-flex flex-1 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition",
+                  viewMode === "table" ? "bg-background text-foreground shadow-soft" : "text-muted-foreground"
+                )}
+                data-testid="scoreboard-view-table"
+                onClick={() => {
+                  handleViewModeChange("table", "mobile");
+                  setMobileViewPanelOpen(false);
+                }}
+                type="button"
+              >
+                <Table2 className="h-4 w-4" />
+                Table
+              </button>
+              <button
+                className={cn(
+                  "inline-flex flex-1 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition",
+                  viewMode === "chart" ? "bg-background text-foreground shadow-soft" : "text-muted-foreground"
+                )}
+                data-testid="scoreboard-view-chart"
+                onClick={() => {
+                  handleViewModeChange("chart", "mobile");
+                  setMobileViewPanelOpen(false);
+                }}
+                type="button"
+              >
+                <BarChart3 className="h-4 w-4" />
+                Bar chart
+              </button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <div className="hidden flex-col gap-3 rounded-[1.7rem] border border-border/70 bg-radix-gray-a-2/65 p-3 sm:flex-row sm:items-center sm:justify-between sm:p-4 md:flex">
         <div className="min-w-0">

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -289,6 +289,83 @@ Result:
 
 - Pass
 
+## Mobile scoreboard disclosure hardening
+
+Date: `2026-03-24`
+
+Goal:
+
+- reproduce the reported mobile dropdown failure instead of assuming the earlier density pass was enough
+- harden the mobile `Details` and `Board view` interactions so they remain reachable and dismissible on event day
+- prove the repaired interactions on both local production and the live production app
+
+What failed before this pass:
+
+- the mobile scoreboard disclosures were implemented as custom absolute overlays
+- that pattern was brittle enough that the panel could render off-screen and its close affordance could become effectively unreachable on mobile
+
+What changed:
+
+- the mobile `Details` and `Board view` controls now open through dialog-based bottom sheets instead of ad hoc positioned overlays
+- the local Playwright rig disables the signed-out public snapshot cache so anonymous proof reflects live seeded state instead of stale cached state
+- a dedicated mobile acceptance spec now proves the disclosures, their dismissal paths, and the chart-table switch on a real mobile viewport
+
+Authoritative implementation paths:
+
+- [/Users/rajeev/Code/hackathon-voting-prototype/components/results-dashboard.tsx](/Users/rajeev/Code/hackathon-voting-prototype/components/results-dashboard.tsx)
+- [/Users/rajeev/Code/hackathon-voting-prototype/components/results-scoreboard-table.tsx](/Users/rajeev/Code/hackathon-voting-prototype/components/results-scoreboard-table.tsx)
+- [/Users/rajeev/Code/hackathon-voting-prototype/lib/competition.ts](/Users/rajeev/Code/hackathon-voting-prototype/lib/competition.ts)
+- [/Users/rajeev/Code/hackathon-voting-prototype/playwright.config.ts](/Users/rajeev/Code/hackathon-voting-prototype/playwright.config.ts)
+- [/Users/rajeev/Code/hackathon-voting-prototype/tests/e2e/mobile-scoreboard-controls.spec.ts](/Users/rajeev/Code/hackathon-voting-prototype/tests/e2e/mobile-scoreboard-controls.spec.ts)
+
+Local validation:
+
+```bash
+pnpm check
+pnpm build
+E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/mobile-scoreboard-controls.spec.ts --project=mobile-dark --reporter=list
+LAYOUT_PROOF=1 E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
+```
+
+Production validation:
+
+```bash
+vercel --prod --yes
+curl -I https://vote.rajeevg.com
+set -a && source .env.vercel-prod && set +a && E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/mobile-scoreboard-controls.spec.ts --project=mobile-dark --reporter=list
+LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
+```
+
+What the proof checked:
+
+- the public mobile scoreboard still reaches the heading and first rows quickly
+- the `Details` sheet opens, renders inside the viewport, and dismisses cleanly
+- the `Board view` sheet opens, switches to chart view, then back to table view
+- the same behavior survives after a manager seeds the live board with real workbook data
+- mid-width and wide desktop layouts remain coherent after the interaction hardening
+
+Artifacts:
+
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-public.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-public.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-summary-open.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-summary-open.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-view-open.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-view-open.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-public.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-public.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-summary-open.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-summary-open.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-view-open.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-view-open.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mid-public.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mid-public.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-wide-desktop-public.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-wide-desktop-public.png)
+
+Observed result:
+
+- the earlier mobile dropdown bug was real and is now fixed
+- the disclosure surfaces are viewport-bounded, scroll-safe, and dismissible through standard dialog behavior
+- the board remains the dominant first destination on mobile
+- the live app preserved the repaired interaction after workbook seeding and chart-table switching
+
+Result:
+
+- Pass
+
 ## Corrected analytics stack completion proof
 
 Date: `2026-03-24`

--- a/docs/viewport-ux-audit.md
+++ b/docs/viewport-ux-audit.md
@@ -4,34 +4,54 @@ Date: `2026-03-24`
 
 Scope:
 
-- public scoreboard layout
-- mobile density and above-the-fold priority
-- board-view controls
-- scoreboard header copy and chips
-- cross-viewport visual rhythm
-- vote-flow usability re-check via fresh Playwright proof
+- mobile scoreboard details and board-view controls
+- above-the-fold priority on the public board
+- single-column hierarchy across mobile, mid-width, tablet, and wide desktop
+- touch, pointer, and keyboard-adjacent reachability for the mobile disclosure surfaces
 
-Method:
+## Audit outcome
 
-- heuristic review using content-priority, scanability, disclosure, and reachability checks
-- fresh local and production Playwright runs after the mobile-density change
-- screenshot review across mobile, mid-width, tablet, and wide desktop
+Overall verdict:
 
-## What changed
+- Pass, after fixing a real mobile interaction defect
 
-The mobile scoreboard now treats supporting chrome as secondary. On small screens:
+What failed before this pass:
 
-- the scoreboard summary details start collapsed
-- the board-view switcher starts collapsed
-- opening either surface uses an overlay panel instead of pushing the table farther down
-- the first scoreboard row stays visible sooner in the initial scan
+- the mobile scoreboard `Details` and `Board view` controls were implemented as custom absolute overlays
+- that pattern was too brittle for event-day confidence
+- once reproduced under focused mobile proof, the disclosure surface could land off-screen and its close affordance could sit outside the viewport
 
-## Screenshots reviewed
+What changed:
 
-- `artifacts/ux-audit/gh-30/prod-mobile-public.png`
-- `artifacts/ux-audit/gh-30/prod-mid-public.png`
-- `artifacts/ux-audit/gh-30/local-tablet-public.png`
-- `artifacts/ux-audit/gh-30/prod-wide-desktop-public.png`
+- the mobile `Details` and `Board view` controls now open as anchored bottom-sheet dialogs rather than ad hoc absolute panels
+- the sheets are scroll-safe, viewport-bounded, and easier to dismiss
+- the signed-out public snapshot cache is disabled for local Playwright proof runs so mobile acceptance evidence is not polluted by stale anonymous state
+- a dedicated mobile-controls acceptance spec now exists in [/Users/rajeev/Code/hackathon-voting-prototype/tests/e2e/mobile-scoreboard-controls.spec.ts](/Users/rajeev/Code/hackathon-voting-prototype/tests/e2e/mobile-scoreboard-controls.spec.ts)
+
+Authoritative implementation paths:
+
+- [/Users/rajeev/Code/hackathon-voting-prototype/components/results-dashboard.tsx](/Users/rajeev/Code/hackathon-voting-prototype/components/results-dashboard.tsx)
+- [/Users/rajeev/Code/hackathon-voting-prototype/components/results-scoreboard-table.tsx](/Users/rajeev/Code/hackathon-voting-prototype/components/results-scoreboard-table.tsx)
+- [/Users/rajeev/Code/hackathon-voting-prototype/components/ui/dialog.tsx](/Users/rajeev/Code/hackathon-voting-prototype/components/ui/dialog.tsx)
+- [/Users/rajeev/Code/hackathon-voting-prototype/lib/competition.ts](/Users/rajeev/Code/hackathon-voting-prototype/lib/competition.ts)
+- [/Users/rajeev/Code/hackathon-voting-prototype/playwright.config.ts](/Users/rajeev/Code/hackathon-voting-prototype/playwright.config.ts)
+
+## Evidence reviewed
+
+Collapsed-state screenshots:
+
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-public.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-public.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-wide-desktop-public.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-wide-desktop-public.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-public.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-public.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mid-public.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mid-public.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-wide-desktop-public.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-wide-desktop-public.png)
+
+Open-state mobile sheet screenshots:
+
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-summary-open.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-summary-open.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-view-open.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/local-mobile-view-open.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-summary-open.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-summary-open.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-view-open.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/ux-audit/gh-39/prod-mobile-view-open.png)
 
 ## Viewport findings
 
@@ -41,17 +61,18 @@ Verdict:
 
 - Pass
 
-What is working:
+What is working now:
 
-- header/nav stays compact enough that the scoreboard heading and first row arrive much earlier
-- supporting board metadata is hidden by default, which reduces pre-scroll cognitive load
-- the board-view control no longer burns a full card above the table when the user has not asked for it
-- the scoreboard remains readable in the first scan without sacrificing access to detail
+- the scoreboard heading and first row remain in the initial scan
+- both disclosure controls are compact when closed
+- opening either control uses a proper bottom sheet that overlaps the UI instead of pushing the scoreboard down
+- the close affordance and the sheet body remain within the viewport
+- chart/table switching works from the sheet and returns the user to the board in the selected view
 
-Why it is safer:
+Why this is safer:
 
-- the supporting sections use progressive disclosure instead of permanent vertical space
-- those panels open over the UI rather than reflowing the table downward, so the board position stays predictable
+- the dialog-based sheet uses Radix focus and dismissal behavior instead of custom outside-click plumbing
+- the sheet can be closed by the visible close button, the overlay, or escape-like browser interactions
 
 ### Mid-width
 
@@ -61,9 +82,9 @@ Verdict:
 
 What is working:
 
-- the single-column reading order holds
-- the scoreboard intro and controls feel intentional instead of stretched
-- chips, heading, and table/chart controls have enough breathing room without creating a dead zone
+- the one-column reading order holds
+- the board remains dominant over supporting chrome
+- controls do not create a dead zone above the first rows
 
 ### Tablet
 
@@ -73,9 +94,8 @@ Verdict:
 
 What is working:
 
-- the layout still reads top-to-bottom without accidental competition between panels
-- the scoreboard remains the dominant block
-- spacing is calmer than mobile while preserving the same mental model
+- the same mental model survives into the larger canvas
+- disclosure and board controls stay subordinate to the ranking itself
 
 ### Wide desktop
 
@@ -85,61 +105,48 @@ Verdict:
 
 What is working:
 
-- the page no longer spends its strongest real estate on explanatory support copy
-- the scoreboard section stays visually dominant
-- supporting status information is compact and subordinate
+- the board remains the first meaningful destination
+- secondary state chips and controls feel compact instead of theatrical
 
-## Usability audit summary
+## Interaction audit summary
 
-### Information hierarchy
-
-- Pass
-- The app now puts the board ahead of explanatory chrome on every viewport.
-
-### Progressive disclosure
+### Mobile details sheet
 
 - Pass
-- Small screens hide optional detail until the user asks for it.
+- Opened, rendered, and dismissed cleanly on local production and the live site.
 
-### Task continuity
-
-- Pass
-- Opening summary or board-view detail does not shove the scoreboard down the page.
-
-### Cognitive load
+### Mobile board-view sheet
 
 - Pass
-- Users see fewer choices before reaching the board, especially on mobile.
+- Opened cleanly and successfully switched between table and chart on local production and the live site.
 
-### Consistency
-
-- Pass
-- The same single-column hierarchy now survives from mobile through desktop.
-
-### Reachability
+### Public-state consistency
 
 - Pass
-- Fresh Playwright proof confirmed the collapsed sections can still be opened, used, and dismissed, and the scoreboard remains usable afterward.
+- The public board kept the same mobile disclosure behavior after the manager seeded real entries on production.
+
+### Proof-rig trustworthiness
+
+- Improved
+- Local anonymous snapshot caching is now disabled during Playwright proof runs so event-day audits are based on live database state rather than stale signed-out cache.
 
 ## Residual risk
 
-- The mobile experience is materially better, but long project names or unusually large team names can still increase row height and make the first visible row denser than the proof fixture. That is a normal content-variance risk, not a structural layout failure.
+- Content variance is still the main residual risk. Very long project names or unusually long summaries can make the first visible row denser than the proof fixture, but the disclosure surfaces themselves are now structurally robust.
 
 ## Validation used for this audit
 
 ```bash
 pnpm check
 pnpm build
-E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --project=desktop-light --reporter=list
-E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --project=mobile-dark --reporter=list
+E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/mobile-scoreboard-controls.spec.ts --project=mobile-dark --reporter=list
 LAYOUT_PROOF=1 E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
+vercel --prod --yes
 curl -I https://vote.rajeevg.com
-E2E_BASE_URL=https://vote.rajeevg.com E2E_JUDGE_AUTH_MODE=ticket pnpm exec playwright test tests/e2e/single-screen-voting.spec.ts --reporter=list
+set -a && source .env.vercel-prod && set +a && E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/mobile-scoreboard-controls.spec.ts --project=mobile-dark --reporter=list
 LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
 ```
 
-## Overall verdict
+## Final note
 
-- Pass
-
-The mobile-first density change did what it needed to do: it restored the scoreboard as the first meaningful destination on small screens without hiding useful controls or breaking the desktop experience.
+This audit is stronger than the earlier mobile-density pass because it found and fixed a real reachability bug before sign-off instead of assuming the existing overlay pattern was good enough.

--- a/lib/competition.ts
+++ b/lib/competition.ts
@@ -14,7 +14,8 @@ const anonymousViewer = {
   isAuthenticated: false,
   isManager: false
 } as const;
-const shouldUsePublicSnapshotCache = process.env.NODE_ENV === "production";
+const shouldUsePublicSnapshotCache =
+  process.env.NODE_ENV === "production" && process.env.DISABLE_PUBLIC_SNAPSHOT_CACHE !== "1";
 const voteContextRetryDelayMs = [0, 100, 250, 500, 1000, 2000];
 
 async function ensureCompetitionState() {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,8 +9,8 @@ const isLocalTarget = /127\.0\.0\.1|localhost/.test(baseURL);
 const repoRoot = process.cwd();
 const usesClerkTestKeys = (process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? "").startsWith("pk_test_");
 const localWebServerCommand = usesClerkTestKeys
-  ? `zsh -lc 'set -a; source .env.local; set +a; pnpm dev --port ${localPort}'`
-  : `zsh -lc 'set -a; source .env.local; set +a; pnpm start --port ${localPort}'`;
+  ? `zsh -lc 'set -a; source .env.local; export DISABLE_PUBLIC_SNAPSHOT_CACHE=1; set +a; pnpm dev --port ${localPort}'`
+  : `zsh -lc 'set -a; source .env.local; export DISABLE_PUBLIC_SNAPSHOT_CACHE=1; set +a; pnpm start --port ${localPort}'`;
 
 export default defineConfig({
   testDir: `${repoRoot}/tests/e2e`,

--- a/tests/e2e/mobile-scoreboard-controls.spec.ts
+++ b/tests/e2e/mobile-scoreboard-controls.spec.ts
@@ -1,0 +1,198 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+
+import { PrismaClient } from "@prisma/client";
+import { devices, expect, test, type Page } from "playwright/test";
+
+const prisma = new PrismaClient();
+
+const MANAGER_EMAIL = "rajeev.gill@omc.com";
+const REPO_ROOT = process.cwd();
+const APP_URL = process.env.E2E_BASE_URL ?? "http://localhost:3017";
+
+function runNodeScript(scriptPath: string, args: string[], extraEnv?: Record<string, string>) {
+  return execFileSync("node", [scriptPath, ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      ...extraEnv
+    },
+    encoding: "utf8"
+  })
+    .trim()
+    .split("\n")
+    .at(-1)!
+    .trim();
+}
+
+function createSignInTicket(baseURL: string, email: string) {
+  return runNodeScript(
+    path.join(REPO_ROOT, "scripts/create-clerk-sign-in-token.mjs"),
+    ["--email", email, "--redirect", "/"],
+    {
+      APP_URL: baseURL
+    }
+  );
+}
+
+function createProofWorkbook(outputPath: string) {
+  return runNodeScript(path.join(REPO_ROOT, "scripts/generate-proof-workbook.mjs"), [outputPath]);
+}
+
+async function resetCompetitionState() {
+  await prisma.vote.deleteMany();
+  await prisma.entryTeamEmail.deleteMany();
+  await prisma.entry.deleteMany();
+  await prisma.competitionState.upsert({
+    where: { id: 1 },
+    update: {
+      votingStatus: "PREPARING",
+      startedAt: null,
+      finalizedAt: null,
+      managerEmail: MANAGER_EMAIL
+    },
+    create: {
+      id: 1,
+      votingStatus: "PREPARING",
+      startedAt: null,
+      finalizedAt: null,
+      managerEmail: MANAGER_EMAIL
+    }
+  });
+}
+
+async function seedCompetitionEntries() {
+  await prisma.entry.create({
+    data: {
+      slug: "aurora-atlas",
+      projectName: "Aurora Atlas",
+      teamName: "Team North Star",
+      summary: "Turns hackathon judging notes into a navigable research map.",
+      isVotingOpen: true,
+      teamEmails: {
+        create: [{ email: "aurora@example.com" }]
+      }
+    }
+  });
+
+  await prisma.entry.create({
+    data: {
+      slug: "signal-bloom",
+      projectName: "Signal Bloom",
+      teamName: "Team Ripple",
+      summary: "Visualises community feedback as a live collaboration signal.",
+      isVotingOpen: true,
+      teamEmails: {
+        create: [{ email: "signal@example.com" }]
+      }
+    }
+  });
+
+  await prisma.entry.create({
+    data: {
+      slug: "harbor-pulse",
+      projectName: "Harbor Pulse",
+      teamName: "Harbor Collective",
+      summary: "Predicts footfall surges for event operations and booth staffing.",
+      isVotingOpen: true,
+      teamEmails: {
+        create: [{ email: "harbor@example.com" }]
+      }
+    }
+  });
+}
+
+async function uploadWorkbook(page: Page, workbookPath: string) {
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    page.getByTestId("manager-upload-dropzone").click()
+  ]);
+  await fileChooser.setFiles(workbookPath);
+  await expect(page.getByText("Imported 3 projects.")).toBeVisible();
+}
+
+async function expectMobileSummaryFlow(page: Page) {
+  await expect(page.getByTestId("scoreboard-mobile-summary-panel")).toHaveCount(0);
+  await page.getByTestId("scoreboard-mobile-summary-toggle").click();
+  await expect(page.getByTestId("scoreboard-mobile-summary-panel")).toBeVisible();
+  await page.getByTestId("scoreboard-mobile-summary-panel").getByRole("button", { name: "Close" }).click();
+  await expect(page.getByTestId("scoreboard-mobile-summary-panel")).toHaveCount(0);
+}
+
+async function expectMobileViewFlow(page: Page) {
+  await expect(page.getByTestId("scoreboard-mobile-view-panel")).toHaveCount(0);
+  await page.getByTestId("scoreboard-mobile-view-toggle").click();
+  await expect(page.getByTestId("scoreboard-mobile-view-panel")).toBeVisible();
+  await page.getByTestId("scoreboard-mobile-view-panel").getByTestId("scoreboard-view-chart").click();
+  await expect(page.getByTestId("scoreboard-chart-view")).toBeVisible();
+  await page.getByTestId("scoreboard-mobile-view-toggle").click();
+  await page.getByTestId("scoreboard-mobile-view-panel").getByTestId("scoreboard-view-table").click();
+  await expect(page.getByTestId("scoreboard-chart-view")).toHaveCount(0);
+  await expect(page.getByTestId("scoreboard-row-aurora-atlas").first()).toBeVisible();
+}
+
+test.describe("mobile scoreboard controls", () => {
+  test.skip(({ browserName }) => browserName !== "chromium", "This audit only targets the chromium mobile project.");
+  test.skip(({ isMobile }) => !isMobile, "This audit only runs on the mobile project.");
+
+  test.beforeEach(async () => {
+    if (APP_URL.includes("localhost")) {
+      await resetCompetitionState();
+      await seedCompetitionEntries();
+    }
+  });
+
+  test.afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test("manager and public users can use the mobile details and board-view overlays", async ({ page, browser }, testInfo) => {
+    const workbookPath = testInfo.outputPath("mobile-controls-workbook.xlsx");
+    createProofWorkbook(workbookPath);
+
+    if (APP_URL.includes("localhost")) {
+      await page.goto(APP_URL);
+      await expect(page.getByTestId("manager-controls")).toHaveCount(0);
+      await expect(page.getByTestId("scoreboard-row-aurora-atlas").first()).toBeVisible();
+      await expectMobileSummaryFlow(page);
+      await expectMobileViewFlow(page);
+      await page.screenshot({ path: testInfo.outputPath("public-mobile-controls-local.png"), fullPage: true });
+      return;
+    }
+
+    const managerTicket = createSignInTicket(APP_URL, MANAGER_EMAIL);
+    await page.goto(managerTicket);
+    await page.waitForURL((url) => url.origin + url.pathname === new URL(APP_URL).origin + "/");
+
+    const resetButton = page.getByTestId("manager-reset-round");
+    if (await resetButton.isVisible().catch(() => false)) {
+      page.once("dialog", (dialog) => dialog.accept());
+      await resetButton.click();
+      await expect(page.getByText("Competition reset. Upload a fresh workbook to start the next dry run.")).toBeVisible();
+    }
+
+    await uploadWorkbook(page, workbookPath);
+    await expect(page.getByTestId("scoreboard-row-aurora-atlas").first()).toBeVisible();
+
+    await expectMobileSummaryFlow(page);
+    await expectMobileViewFlow(page);
+    await page.screenshot({ path: testInfo.outputPath("manager-mobile-controls.png"), fullPage: true });
+
+    const publicContext = await browser.newContext({
+      ...devices["Pixel 7"],
+      colorScheme: "dark",
+      storageState: { cookies: [], origins: [] }
+    });
+    const publicPage = await publicContext.newPage();
+    await publicPage.goto(APP_URL);
+    await expect(publicPage.getByTestId("manager-controls")).toHaveCount(0);
+    await expect(publicPage.getByTestId("scoreboard-row-aurora-atlas").first()).toBeVisible();
+
+    await expectMobileSummaryFlow(publicPage);
+    await expectMobileViewFlow(publicPage);
+    await publicPage.screenshot({ path: testInfo.outputPath("public-mobile-controls.png"), fullPage: true });
+
+    await publicContext.close();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the brittle mobile scoreboard overlays with dialog-based bottom sheets
- add focused mobile acceptance proof for the details and board-view controls
- record the real failure, repair, and fresh viewport evidence in the repo docs

## Validation
- pnpm check
- pnpm build
- E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/mobile-scoreboard-controls.spec.ts --project=mobile-dark --reporter=list
- LAYOUT_PROOF=1 E2E_BASE_URL=http://localhost:3017 pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
- curl -I https://vote.rajeevg.com
- set -a && source .env.vercel-prod && set +a && E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/mobile-scoreboard-controls.spec.ts --project=mobile-dark --reporter=list
- LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed mobile Details and Board view panels that were previously cut off-screen or difficult to dismiss by implementing better-contained dialog-based sheets with improved viewport handling.

* **New Features**
  * Enhanced mobile accessibility for scoreboard control toggles with screen reader support and improved keyboard navigation.

* **Tests**
  * Added comprehensive mobile interaction tests for scoreboard controls across multiple viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->