### PR TITLE
gh-41: finalize event-day risk hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,17 +188,21 @@ The Playwright suite covers:
 Cheap event-day readiness checks:
 
 ```bash
-pnpm test tests/readiness.integration.test.ts
-pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 250
+pnpm exec vitest run tests/readiness.integration.test.ts tests/votes.integration.test.ts --reporter=verbose
+pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 500
+set -a && source .env.vercel-prod && set +a
+pnpm readiness:smoke -- --base-url https://vote.rajeevg.com
 ```
 
 These checks prove two different things:
 
-- `tests/readiness.integration.test.ts` simulates 50 concurrent judges scoring a round in waves against the real Prisma-backed vote logic.
-- `readiness:public` sends 250 public scoreboard requests with 50-way concurrency to confirm the live site stays responsive under the expected spectator load without requiring a paid load-testing service.
+- the Vitest pair covers vote locking, self-vote blocking, project-close behavior, reset behavior, and the 50-judge readiness waves against the real Prisma-backed vote logic
+- `readiness:public` sends 500 public scoreboard requests with 50-way concurrency to confirm the live site stays responsive under the expected spectator load without requiring a paid load-testing service
+- `readiness:smoke` is the manager/judge/public production smoke path that resets to a clean start, uploads the workbook, opens voting, casts a real judge vote, and confirms the public board refreshes
 
 Proof notes live in [proof.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/proof.md).
 Viewport-specific appearance and usability findings live in [viewport-ux-audit.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/viewport-ux-audit.md).
+Event-day operating guidance and recovery steps live in [event-day-runbook.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/event-day-runbook.md).
 Analytics implementation notes live in [google-tagging-stack.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/google-tagging-stack.md).
 Analytics audit notes live in [analytics-audit.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/analytics-audit.md).
 Promoted GA dimension and metric definitions live in [google-tagging-stack.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/google-tagging-stack.md#promoted-ga-custom-definitions).

--- a/docs/event-day-runbook.md
+++ b/docs/event-day-runbook.md
@@ -1,0 +1,449 @@
+# Event-Day Risk Runbook
+
+Date: `2026-03-24`
+
+Purpose:
+
+- give the manager a practical, low-stress operating guide for the hackathon judging day
+- list the risks most likely to affect smooth operation
+- show how to detect, prevent, and recover from those risks quickly
+
+This is the operational companion to:
+
+- [/Users/rajeev/Code/hackathon-voting-prototype/docs/operating-model.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/operating-model.md)
+- [/Users/rajeev/Code/hackathon-voting-prototype/docs/proof.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/proof.md)
+
+## Executive summary
+
+Current readiness verdict:
+
+- Pass for a room-sized event if the manager follows the preflight and recovery steps below.
+
+What this app is currently strongest at:
+
+- public scoreboard reads under spectator-style traffic
+- one-screen manager workflow for upload, begin voting, per-entry control, finalize, and export
+- judge voting with Google and email-code auth
+- self-vote blocking from workbook team emails
+- mobile scoreboard disclosures and cross-device score freshness
+
+What still needs human discipline on the day:
+
+- start from a clean round
+- avoid unnecessary resets once judging is underway
+- use the remaining-votes tracker before finalizing
+- fall back to email-code auth if Google SSO is having a bad moment
+
+## Verified readiness evidence
+
+Fresh evidence from this pass:
+
+- `pnpm exec vitest run tests/votes.integration.test.ts tests/readiness.integration.test.ts --reporter=verbose`
+- `pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 500`
+- `set -a && source .env.vercel-prod && set +a && pnpm readiness:smoke -- --base-url https://vote.rajeevg.com`
+- `LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list`
+
+Current live public-read result:
+
+- `500/500` requests completed
+- `0` failures
+- `p50 150.45ms`
+- `p95 1120.87ms`
+- `p99 1302.27ms`
+- `max 1598.98ms`
+
+Current live smoke result:
+
+- manager signed in
+- manager reset an already-live round to a clean start
+- manager uploaded a workbook
+- manager opened voting
+- judge signed in and cast a real score
+- manager tracker updated
+- public board reflected the vote
+
+Smoke artifacts:
+
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/event-day-smoke/2026-03-24T19-56-50.092Z/event-day-smoke-public.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/event-day-smoke/2026-03-24T19-56-50.092Z/event-day-smoke-public.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/event-day-smoke/2026-03-24T19-56-50.092Z/summary.json](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/event-day-smoke/2026-03-24T19-56-50.092Z/summary.json)
+
+## Preflight checklist
+
+Run this once around 30 to 60 minutes before judges arrive.
+
+1. Confirm the live site is reachable.
+
+```bash
+curl -I https://vote.rajeevg.com
+```
+
+Expected:
+
+- `HTTP/2 200`
+
+2. Confirm the public board still handles expected spectator load.
+
+```bash
+pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 500
+```
+
+Expected:
+
+- `failures: 0`
+- all statuses `200`
+
+3. Run the production smoke path.
+
+```bash
+set -a && source .env.vercel-prod && set +a
+pnpm readiness:smoke -- --base-url https://vote.rajeevg.com
+```
+
+Expected:
+
+- script exits `0`
+- `result: "pass"`
+
+4. Sign into the live app as the manager and visually confirm:
+
+- the workbook you intend to use is ready
+- the board is either intentionally empty or intentionally loaded
+- the manager tracker is visible once voting is open
+- the footer privacy controls are present
+
+## Five-minute checklist
+
+Run this right before judges begin.
+
+1. Sign in as `rajeev.gill@omc.com`.
+2. If the board contains stale rehearsal data, click `Reset dry run`.
+3. Upload the final workbook.
+4. Scan the scoreboard for obvious row or email mistakes.
+5. Click `Begin voting`.
+6. Keep the manager screen open during judging.
+7. Use the remaining-votes tracker before finalizing.
+
+## Risk register
+
+### 1. Dirty round state at the start of the event
+
+Symptom:
+
+- the board already shows entries or `Voting live` before the real round has started
+
+Cause:
+
+- a rehearsal or proof run left state behind
+
+Prevention:
+
+- run the smoke command before judges arrive
+
+Recovery:
+
+1. Sign in as the manager.
+2. Click `Reset dry run`.
+3. Re-upload the final workbook.
+4. Confirm the board contents are correct before reopening voting.
+
+Severity:
+
+- High
+
+### 2. First votes fail right after the manager opens the round
+
+Symptom:
+
+- a judge sees `Voting is not currently open.` immediately after the manager just opened voting
+
+Cause:
+
+- transient read-after-write lag right after opening the round or replacing entries
+
+Prevention:
+
+- avoid asking judges to vote in the same instant that the manager clicks `Begin voting`
+- give the board a few seconds to settle after upload or round-open
+
+Recovery:
+
+1. Ask the judge to refresh the page once.
+2. If needed, wait 3 to 5 seconds and reopen the modal.
+3. If multiple judges report it at once, pause for 10 seconds, then retry.
+
+Notes:
+
+- the vote path now retries this transition internally before failing
+
+Severity:
+
+- Medium
+
+### 3. Accidental reset while the round is active
+
+Symptom:
+
+- the board suddenly empties and votes disappear
+
+Cause:
+
+- manager intentionally or accidentally clicked `Reset dry run`
+
+Prevention:
+
+- do not use reset during the live round unless recovery is impossible any other way
+- keep one manager laptop dedicated to the operations view
+
+Recovery:
+
+1. Re-upload the workbook immediately.
+2. Reopen voting.
+3. Tell judges to refresh and continue.
+4. If the reset happened late in judging, use the exported workbook from the last finalized rehearsal only as a reference, not as a data restore.
+
+Important limitation:
+
+- reset is destructive; it is a salvage tool, not a normal live-round control
+
+Severity:
+
+- High
+
+### 4. Google sign-in is flaky for a judge
+
+Symptom:
+
+- judge cannot complete Google auth
+
+Cause:
+
+- Google SSO popup or vendor-side auth issue
+
+Prevention:
+
+- remind judges that email-code auth is fully supported
+
+Recovery:
+
+1. Open the judge sign-in modal.
+2. Enter the judge email.
+3. Use email-code auth instead of Google.
+4. Return to the app and continue voting.
+
+Severity:
+
+- Medium
+
+### 5. Mobile users say the board controls are broken
+
+Symptom:
+
+- users cannot find details or chart controls on mobile
+
+Cause:
+
+- the controls are now collapsed by design to keep the board higher above the fold
+
+Prevention:
+
+- mention that `Details` and `Board view` are tap-to-open sheets on mobile
+
+Recovery:
+
+1. Tap `Details` for board summary chips.
+2. Tap `Board view` to switch between table and bar chart.
+3. Close either sheet and continue using the board.
+
+Severity:
+
+- Low
+
+### 6. A judge cannot vote on a project
+
+Symptom:
+
+- modal says voting is paused, finalized, or self-voting is blocked
+
+Cause:
+
+- manager closed that project
+- the round is finalized
+- the judge email matches an uploaded team email
+
+Recovery:
+
+- `Voting is paused`
+  - manager reopens that project from the row toggle
+- `Judging is finalized`
+  - no recovery; results are locked
+- `Self-voting is blocked`
+  - expected behavior; judge must score other eligible entries
+
+Severity:
+
+- Medium
+
+### 7. Finalize button does not appear or remains disabled
+
+Symptom:
+
+- manager cannot finalize even though judging feels nearly done
+
+Cause:
+
+- one or more participating judges still owe votes on open, eligible projects
+
+Recovery:
+
+1. Check the remaining-votes tracker.
+2. Read the outstanding judge emails and project list directly from that tracker.
+3. Either:
+   - get those judges to finish their remaining votes
+   - or intentionally close specific projects if they should no longer count toward completion
+
+Severity:
+
+- Medium
+
+### 8. Workbook upload fails
+
+Symptom:
+
+- upload returns row validation errors
+
+Cause:
+
+- missing project name
+- no team email on a row
+- duplicate project names
+- malformed email content
+
+Recovery:
+
+1. Read the row-level validation message in the manager panel.
+2. Fix the workbook locally.
+3. Upload again.
+
+Fallback:
+
+- keep the prior loaded workbook live until the corrected one is ready
+
+Severity:
+
+- Medium
+
+### 9. Public board appears slow or stale
+
+Symptom:
+
+- score changes do not appear immediately for spectators
+
+Cause:
+
+- short public cache window
+- focused-tab refresh rules
+- temporary network lag
+
+Recovery:
+
+1. Wait a few seconds.
+2. Switch tabs or refocus the browser.
+3. Manually refresh if needed.
+
+Notes:
+
+- the board auto-refreshes while judging is open
+- the public read cache is intentionally short-lived
+
+Severity:
+
+- Low
+
+### 10. Vercel or database degradation
+
+Symptom:
+
+- multiple judges cannot load or save anything
+- `curl -I https://vote.rajeevg.com` stops returning `200`
+- public load probe starts showing failures
+
+Recovery:
+
+1. Re-run:
+
+```bash
+curl -I https://vote.rajeevg.com
+pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 20 --requests 100
+```
+
+2. If failures persist:
+   - stop asking judges to cast new votes for a moment
+   - keep the manager screen open
+   - do not reset the round unless absolutely necessary
+3. Use Vercel to inspect the current production deployment and logs:
+
+```bash
+vercel inspect vote.rajeevg.com
+vercel logs vote.rajeevg.com
+```
+
+Severity:
+
+- High
+
+## Recovery patterns by symptom
+
+### “We need a clean start”
+
+Use:
+
+- manager `Reset dry run`
+
+Then:
+
+- upload workbook
+- confirm rows
+- begin voting
+
+### “A judge is stuck signing in”
+
+Use:
+
+- email-code auth fallback
+
+### “A project should not count right now”
+
+Use:
+
+- manager per-entry `close to new votes` toggle
+
+### “Why can’t we finalize?”
+
+Use:
+
+- manager remaining-votes tracker
+
+### “The public board feels odd or slow”
+
+Use:
+
+- `curl`
+- `pnpm readiness:public`
+- manual refresh/focus return
+
+## Recommended on-day command pack
+
+```bash
+curl -I https://vote.rajeevg.com
+pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 500
+set -a && source .env.vercel-prod && set +a
+pnpm readiness:smoke -- --base-url https://vote.rajeevg.com
+```
+
+## Final operating advice
+
+- Keep one manager laptop signed in for the whole event.
+- Do not use reset casually once real votes have started.
+- Prefer reopening or closing individual projects over destructive round resets.
+- Use the remaining-votes tracker as the source of truth before finalizing.
+- If Google auth wobbles, move judges to email-code auth immediately instead of waiting for vendor behavior to recover.

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -171,3 +171,5 @@ This keeps the rule coherent without introducing a separate roster-management sy
 - The vote path tolerates a short read-after-write consistency window right after a round opens or a workbook-driven field is created, so immediate first votes are less likely to fail on pooled or remote Postgres infrastructure.
 - The repo includes a cheap public-read probe at `pnpm readiness:public` so the live site can be checked before the event without extra vendor spend.
 - Concurrent write readiness is covered in `tests/readiness.integration.test.ts`, which runs the real vote logic with 50 concurrent judges in project-by-project waves.
+- The reusable production smoke path lives at `pnpm readiness:smoke`.
+- The manager-facing risk and recovery guide lives in [event-day-runbook.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/event-day-runbook.md).

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -539,6 +539,77 @@ Result:
 - The live production verification email is already understandable and app-branded through the Clerk application name and production sending domain.
 - Production verification-email template editing is still blocked by Clerk's current Hobby plan. Deeper subject/body template edits require a plan upgrade or custom delivery.
 
+## Final event-day risk pass
+
+Date: `2026-03-24`
+
+Goal:
+
+- ruthlessly probe the event-day risks that could still hurt a live judging session
+- fix any real app or proof weakness uncovered
+- leave a reusable operational smoke command and a durable recovery runbook
+
+Fresh command set:
+
+```bash
+pnpm check
+pnpm build
+pnpm exec vitest run tests/votes.integration.test.ts tests/readiness.integration.test.ts --reporter=verbose
+pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 500
+set -a && source .env.vercel-prod && set +a
+pnpm readiness:smoke -- --base-url https://vote.rajeevg.com
+LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list
+```
+
+Real issues uncovered in this pass:
+
+- the vote path could still surface a false `Voting is not currently open.` during the immediate first voting wave after round-open or fresh entry creation, because the retry window was too short for the remote database consistency lag seen in the readiness simulation
+- the production proof path depended too much on the app already being in a clean state, which is unsafe for on-the-day verification
+- the ad hoc final smoke flow was too brittle around responsive duplicate elements, so it needed a purpose-built operational smoke command
+
+What changed:
+
+- widened the vote submission context retry window in [/Users/rajeev/Code/hackathon-voting-prototype/lib/competition.ts](/Users/rajeev/Code/hackathon-voting-prototype/lib/competition.ts)
+- made the production browser proof clean-start aware in [/Users/rajeev/Code/hackathon-voting-prototype/tests/e2e/single-screen-voting.spec.ts](/Users/rajeev/Code/hackathon-voting-prototype/tests/e2e/single-screen-voting.spec.ts)
+- added a reusable production smoke command in [/Users/rajeev/Code/hackathon-voting-prototype/scripts/event-day-smoke.mjs](/Users/rajeev/Code/hackathon-voting-prototype/scripts/event-day-smoke.mjs)
+- exposed that smoke command as `pnpm readiness:smoke`
+- documented the operating and recovery playbook in [/Users/rajeev/Code/hackathon-voting-prototype/docs/event-day-runbook.md](/Users/rajeev/Code/hackathon-voting-prototype/docs/event-day-runbook.md)
+
+Observed results:
+
+- the shared local risk pack passed:
+  - `tests/votes.integration.test.ts`
+  - `tests/readiness.integration.test.ts`
+- the live public read probe passed:
+  - `500/500` completed
+  - `0` failures
+  - `p50 150.45ms`
+  - `p95 1120.87ms`
+  - `p99 1302.27ms`
+  - `max 1598.98ms`
+- the live event-day smoke command passed:
+  - manager signed in
+  - manager reset a dirty live round to a clean start
+  - public board showed the empty pre-upload state
+  - manager uploaded the workbook
+  - manager opened voting
+  - judge signed in and cast a real score
+  - manager tracker remained available
+  - public board reflected the new vote
+- the live breakpoint audit still passed after the hardening:
+  - `6 passed`
+  - `2 skipped`
+
+Artifacts:
+
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/event-day-smoke/2026-03-24T19-56-50.092Z/event-day-smoke-public.png](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/event-day-smoke/2026-03-24T19-56-50.092Z/event-day-smoke-public.png)
+- [/Users/rajeev/Code/hackathon-voting-prototype/artifacts/event-day-smoke/2026-03-24T19-56-50.092Z/summary.json](/Users/rajeev/Code/hackathon-voting-prototype/artifacts/event-day-smoke/2026-03-24T19-56-50.092Z/summary.json)
+- fresh breakpoint artifacts under `artifacts/playwright/scoreboard-breakpoints-*`
+
+Result:
+
+- Pass, with the runbook now required as part of event-day operations
+
 ## Production analytics proof
 
 Date: `2026-03-24`

--- a/lib/competition.ts
+++ b/lib/competition.ts
@@ -16,7 +16,8 @@ const anonymousViewer = {
 } as const;
 const shouldUsePublicSnapshotCache =
   process.env.NODE_ENV === "production" && process.env.DISABLE_PUBLIC_SNAPSHOT_CACHE !== "1";
-const voteContextRetryDelayMs = [0, 100, 250, 500, 1000, 2000];
+const voteContextRetryDelayMs = [0, 100, 250, 500, 1000, 2000, 4000];
+const voteWriteRetryDelayMs = [0, 50, 125, 250, 500];
 
 async function ensureCompetitionState() {
   const existingState = await withPrismaRetry(() =>
@@ -327,29 +328,66 @@ export async function submitJudgeVote({
     throw new Error("Team members cannot vote on their own project.");
   }
 
-  try {
-    await withPrismaRetry(() =>
-      prisma.vote.create({
-        data: {
-          entryId,
-          judgeEmail: normalizedJudgeEmail,
-          judgeUserId,
-          score
-        }
-      })
-    );
-  } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === "P2002"
-    ) {
-      throw new Error("You've already scored this project. Votes lock after submission.");
+  for (const delayMs of voteWriteRetryDelayMs) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, delayMs);
+      });
     }
 
-    throw error;
+    try {
+      await withPrismaRetry(() =>
+        prisma.vote.create({
+          data: {
+            entryId,
+            judgeEmail: normalizedJudgeEmail,
+            judgeUserId,
+            score
+          }
+        })
+      );
+      safeRevalidateHome();
+      return;
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        throw new Error("You've already scored this project. Votes lock after submission.");
+      }
+
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2003"
+      ) {
+        const latestContext = await resolveVoteSubmissionContext(entryId);
+
+        if (!latestContext.state || latestContext.state.votingStatus !== "OPEN") {
+          throw new Error("Voting is not currently open.");
+        }
+
+        if (!latestContext.entry) {
+          if (delayMs === voteWriteRetryDelayMs.at(-1)) {
+            throw new Error("That project is no longer available. Refresh the board and try again.");
+          }
+
+          continue;
+        }
+
+        if (!latestContext.entry.isVotingOpen) {
+          throw new Error("Voting is currently closed for this project.");
+        }
+
+        if (delayMs !== voteWriteRetryDelayMs.at(-1)) {
+          continue;
+        }
+      }
+
+      throw error;
+    }
   }
 
-  safeRevalidateHome();
+  throw new Error("We could not save that vote right now. Refresh the board and try again.");
 }
 
 export async function setEntryVotingAvailability({

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clerk:ticket": "node scripts/create-clerk-sign-in-token.mjs",
     "proof:workbook": "node scripts/generate-proof-workbook.mjs",
     "readiness:public": "node scripts/load-scoreboard.mjs",
+    "readiness:smoke": "node scripts/event-day-smoke.mjs",
     "test:e2e": "playwright test",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/scripts/event-day-smoke.mjs
+++ b/scripts/event-day-smoke.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+import { chromium } from "playwright";
+
+const REPO_ROOT = process.cwd();
+const MANAGER_EMAIL = "rajeev.gill@omc.com";
+const JUDGE_EMAIL = "judge.one+clerk_test@example.com";
+
+function parseArg(flag, fallback) {
+  const index = process.argv.indexOf(flag);
+  if (index === -1) return fallback;
+  return process.argv[index + 1] ?? fallback;
+}
+
+const baseURL = parseArg("--base-url", "https://vote.rajeevg.com");
+const artifactDir = parseArg(
+  "--artifacts",
+  path.join(REPO_ROOT, "artifacts", "event-day-smoke", new Date().toISOString().replaceAll(":", "-"))
+);
+
+fs.mkdirSync(artifactDir, { recursive: true });
+
+function runNodeScript(scriptPath, args, extraEnv = {}) {
+  return execFileSync("node", [scriptPath, ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      ...extraEnv
+    },
+    encoding: "utf8"
+  })
+    .trim()
+    .split("\n")
+    .at(-1)
+    .trim();
+}
+
+function createSignInTicket(email) {
+  return runNodeScript(
+    path.join(REPO_ROOT, "scripts/create-clerk-sign-in-token.mjs"),
+    ["--email", email, "--redirect", "/"],
+    { APP_URL: baseURL }
+  );
+}
+
+function createProofWorkbook(outputPath) {
+  return runNodeScript(path.join(REPO_ROOT, "scripts/generate-proof-workbook.mjs"), [outputPath]);
+}
+
+async function signInWithTicket(page, email) {
+  const ticketUrl = createSignInTicket(email);
+  await page.goto(ticketUrl, { waitUntil: "domcontentloaded" });
+  await page.waitForURL((url) => url.origin + url.pathname === new URL(baseURL).origin + "/");
+}
+
+async function ensureCleanManagerStart(page) {
+  console.log("step=manager_sign_in");
+  await signInWithTicket(page, MANAGER_EMAIL);
+  await page.goto(baseURL, { waitUntil: "domcontentloaded" });
+
+  const stateBadge = page.locator('[data-testid="competition-state-badge"]:visible').first();
+  const stateText = (await stateBadge.textContent())?.trim();
+  const hasEntries = (await page.getByTestId(/^scoreboard-row-/).count()) > 0;
+
+  if (stateText === "Preparing" && !hasEntries) {
+    console.log("step=clean_start_already_preparing");
+    return;
+  }
+
+  console.log(`step=manager_reset_required state=${stateText ?? "unknown"} hasEntries=${hasEntries}`);
+  const resetButton = page.getByTestId("manager-reset-round");
+  await resetButton.waitFor({ state: "visible", timeout: 10000 });
+  page.once("dialog", (dialog) => void dialog.accept());
+  await resetButton.click();
+  await page.getByText("Competition reset. Upload a fresh workbook to start the next dry run.").waitFor({
+    state: "visible",
+    timeout: 15000
+  });
+  await page.getByTestId("scoreboard-empty-heading").waitFor({ state: "visible", timeout: 15000 });
+  console.log("step=manager_reset_complete");
+}
+
+async function uploadWorkbook(page, workbookPath) {
+  console.log("step=upload_workbook");
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    page.getByTestId("manager-upload-dropzone").click()
+  ]);
+  await fileChooser.setFiles(workbookPath);
+  await page.getByText("Imported 3 projects.").waitFor({ state: "visible", timeout: 15000 });
+  await page.locator('[data-testid="scoreboard-row-aurora-atlas"]:visible').first().waitFor({
+    state: "visible",
+    timeout: 15000
+  });
+}
+
+async function beginVoting(page) {
+  console.log("step=begin_voting");
+  await page.getByTestId("manager-begin-voting").click();
+  await page.locator('[data-testid="competition-state-badge"]:visible').first().waitFor({ state: "visible" });
+}
+
+async function castJudgeVote(page) {
+  console.log("step=judge_sign_in");
+  await signInWithTicket(page, JUDGE_EMAIL);
+  console.log("step=judge_vote");
+  await page.locator('[data-testid="scoreboard-action-aurora-atlas"]:visible').first().click();
+  await page.getByTestId("score-option-7").click();
+  await page.getByTestId("submit-vote").click();
+  await page.getByText("Judge", { exact: true }).waitFor({ state: "visible", timeout: 10000 });
+  await page.locator('[data-testid="scoreboard-action-aurora-atlas"]:visible').first().waitFor({
+    state: "visible",
+    timeout: 10000
+  });
+}
+
+async function assertPublicRefresh(page) {
+  console.log("step=public_refresh_check");
+  await page.goto(baseURL, { waitUntil: "domcontentloaded" });
+  await page.locator('[data-testid="scoreboard-row-aurora-atlas"]:visible').first().waitFor({
+    state: "visible",
+    timeout: 10000
+  });
+  await page.waitForFunction(() => {
+    const row = Array.from(document.querySelectorAll('[data-testid="scoreboard-row-aurora-atlas"]')).find(
+      (element) => element instanceof HTMLElement && element.offsetParent !== null
+    );
+    return row?.textContent?.includes("1 vote");
+  });
+}
+
+const workbookPath = path.join(os.tmpdir(), `event-day-smoke-${Date.now()}.xlsx`);
+createProofWorkbook(workbookPath);
+
+const browser = await chromium.launch({ headless: true });
+const managerContext = await browser.newContext({
+  viewport: { width: 1440, height: 1100 },
+  colorScheme: "light",
+  acceptDownloads: true
+});
+const judgeContext = await browser.newContext({
+  viewport: { width: 1440, height: 1100 },
+  colorScheme: "light"
+});
+const publicContext = await browser.newContext({
+  viewport: { width: 1440, height: 1100 },
+  colorScheme: "light",
+  storageState: { cookies: [], origins: [] }
+});
+
+const managerPage = await managerContext.newPage();
+const judgePage = await judgeContext.newPage();
+const publicPage = await publicContext.newPage();
+
+try {
+  await ensureCleanManagerStart(managerPage);
+  console.log("step=public_empty_board_check");
+  await publicPage.goto(baseURL, { waitUntil: "domcontentloaded" });
+  await publicPage.getByTestId("scoreboard-empty-heading").waitFor({ state: "visible", timeout: 10000 });
+
+  await uploadWorkbook(managerPage, workbookPath);
+  await beginVoting(managerPage);
+  await castJudgeVote(judgePage);
+
+  console.log("step=manager_tracker_check");
+  await managerPage.goto(baseURL, { waitUntil: "domcontentloaded" });
+  await managerPage.getByTestId("manager-remaining-votes").waitFor({ state: "visible", timeout: 10000 });
+
+  await assertPublicRefresh(publicPage);
+  await publicPage.screenshot({
+    path: path.join(artifactDir, "event-day-smoke-public.png"),
+    fullPage: true
+  });
+
+  const summary = {
+    baseURL,
+    artifactDir,
+    workbookPath,
+    result: "pass"
+  };
+
+  fs.writeFileSync(path.join(artifactDir, "summary.json"), JSON.stringify(summary, null, 2));
+  console.log(JSON.stringify(summary, null, 2));
+} catch (error) {
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  fs.writeFileSync(path.join(artifactDir, "error.txt"), message);
+  console.error(message);
+  process.exitCode = 1;
+} finally {
+  await Promise.all([managerContext.close(), judgeContext.close(), publicContext.close()]);
+  await browser.close();
+}

--- a/tests/e2e/event-day-smoke.spec.ts
+++ b/tests/e2e/event-day-smoke.spec.ts
@@ -1,0 +1,162 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+
+import { PrismaClient } from "@prisma/client";
+import { expect, test, type Browser, type Page } from "playwright/test";
+
+const prisma = new PrismaClient();
+
+const MANAGER_EMAIL = "rajeev.gill@omc.com";
+const JUDGE_EMAIL = "judge.one+clerk_test@example.com";
+const REPO_ROOT = process.cwd();
+
+function runNodeScript(scriptPath: string, args: string[], extraEnv?: Record<string, string>) {
+  return execFileSync("node", [scriptPath, ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      ...extraEnv
+    },
+    encoding: "utf8"
+  })
+    .trim()
+    .split("\n")
+    .at(-1)!
+    .trim();
+}
+
+function createSignInTicket(baseURL: string, email: string) {
+  return runNodeScript(
+    path.join(REPO_ROOT, "scripts/create-clerk-sign-in-token.mjs"),
+    ["--email", email, "--redirect", "/"],
+    {
+      APP_URL: baseURL
+    }
+  );
+}
+
+function createProofWorkbook(outputPath: string) {
+  return runNodeScript(path.join(REPO_ROOT, "scripts/generate-proof-workbook.mjs"), [outputPath]);
+}
+
+async function resetCompetitionState() {
+  await prisma.vote.deleteMany();
+  await prisma.entryTeamEmail.deleteMany();
+  await prisma.entry.deleteMany();
+  await prisma.competitionState.upsert({
+    where: { id: 1 },
+    update: {
+      votingStatus: "PREPARING",
+      startedAt: null,
+      finalizedAt: null,
+      managerEmail: MANAGER_EMAIL
+    },
+    create: {
+      id: 1,
+      votingStatus: "PREPARING",
+      startedAt: null,
+      finalizedAt: null,
+      managerEmail: MANAGER_EMAIL
+    }
+  });
+}
+
+function createDesktopContext(browser: Browser) {
+  return browser.newContext({
+    viewport: { width: 1440, height: 1100 },
+    colorScheme: "light",
+    acceptDownloads: true
+  });
+}
+
+async function signInWithTicket(page: Page, baseURL: string, email: string) {
+  const ticketUrl = createSignInTicket(baseURL, email);
+  await page.goto(ticketUrl);
+  await page.waitForURL((url) => url.origin + url.pathname === new URL(baseURL).origin + "/");
+}
+
+async function uploadWorkbook(page: Page, workbookPath: string) {
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    page.getByTestId("manager-upload-dropzone").click()
+  ]);
+  await fileChooser.setFiles(workbookPath);
+  await expect(page.getByText("Imported 3 projects.")).toBeVisible();
+}
+
+async function ensureManagerCleanStart(page: Page, baseURL: string) {
+  await signInWithTicket(page, baseURL, MANAGER_EMAIL);
+  await page.goto("/");
+
+  const stateBadge = page.locator('[data-testid="competition-state-badge"]:visible').first();
+  const stateText = (await stateBadge.textContent())?.trim();
+  const hasEntries = (await page.getByTestId(/^scoreboard-row-/).count()) > 0;
+
+  if (stateText === "Preparing" && !hasEntries) {
+    return;
+  }
+
+  const resetButton = page.getByTestId("manager-reset-round");
+  await expect(resetButton).toBeVisible();
+  page.once("dialog", (dialog) => void dialog.accept());
+  await resetButton.click();
+  await expect(page.getByText("Competition reset. Upload a fresh workbook to start the next dry run.")).toBeVisible();
+  await expect(page.getByTestId("scoreboard-empty-heading")).toBeVisible();
+}
+
+test.afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test("event-day smoke: manager can recover to a clean round and a judge/public path still works", async ({
+  baseURL,
+  browser
+}, testInfo) => {
+  testInfo.setTimeout(180000);
+  const workbookPath = testInfo.outputPath("event-day-smoke-workbook.xlsx");
+  createProofWorkbook(workbookPath);
+
+  if (baseURL?.includes("localhost") || baseURL?.includes("127.0.0.1")) {
+    await resetCompetitionState();
+  }
+
+  const managerContext = await createDesktopContext(browser);
+  const managerPage = await managerContext.newPage();
+  const judgeContext = await createDesktopContext(browser);
+  const judgePage = await judgeContext.newPage();
+  const publicContext = await browser.newContext({
+    viewport: { width: 1440, height: 1100 },
+    colorScheme: "light",
+    storageState: { cookies: [], origins: [] }
+  });
+  const publicPage = await publicContext.newPage();
+
+  await ensureManagerCleanStart(managerPage, baseURL!);
+
+  await publicPage.goto("/");
+  await expect(publicPage.getByTestId("scoreboard-empty-heading")).toBeVisible();
+
+  await uploadWorkbook(managerPage, workbookPath);
+  await managerPage.getByTestId("manager-begin-voting").click();
+  await expect(managerPage.locator('[data-testid="competition-state-badge"]:visible').first()).toHaveText("Voting live");
+
+  await signInWithTicket(judgePage, baseURL!, JUDGE_EMAIL);
+  await judgePage.getByTestId("scoreboard-action-aurora-atlas").first().click();
+  await judgePage.getByTestId("score-option-7").click();
+  await judgePage.getByTestId("submit-vote").click();
+  await expect(judgePage.getByText("Judge", { exact: true })).toBeVisible();
+  await expect(judgePage.getByTestId("scoreboard-action-aurora-atlas").first()).toContainText("Scored");
+
+  await managerPage.goto("/");
+  await expect(managerPage.getByTestId("manager-remaining-votes")).toContainText("Judge");
+
+  await publicPage.goto("/");
+  await expect(publicPage.getByTestId("scoreboard-row-aurora-atlas").first()).toContainText("1 vote", {
+    timeout: 12000
+  });
+
+  await publicPage.screenshot({ path: testInfo.outputPath("event-day-smoke-public.png"), fullPage: true });
+
+  await Promise.all([managerContext.close(), judgeContext.close(), publicContext.close()]);
+});

--- a/tests/e2e/single-screen-voting.spec.ts
+++ b/tests/e2e/single-screen-voting.spec.ts
@@ -151,7 +151,7 @@ async function signInWithTicket(page: Page, baseURL: string, email: string, expe
   const ticketUrl = createSignInTicket(baseURL, email);
   await page.goto(ticketUrl);
   await page.waitForURL((url) => url.origin + url.pathname === new URL(baseURL).origin + "/");
-  await expect(page.getByText(expectedRoleLabel, { exact: true })).toBeVisible();
+  await expect(page.locator("span", { hasText: expectedRoleLabel }).first()).toBeVisible();
 }
 
 async function signInJudgeWithEmailCode(page: Page, email: string) {
@@ -228,6 +228,31 @@ async function expectCompetitionStateBadge(page: Page, expectedText: string) {
   await expect(badge).toHaveText(expectedText);
 }
 
+async function ensureManagerCleanStart(page: Page, baseURL: string) {
+  await signInWithTicket(page, baseURL, MANAGER_EMAIL, "Manager");
+  await page.goto("/");
+
+  const badge = page.locator('[data-testid="competition-state-badge"]:visible').first();
+  const stateText = (await badge.textContent())?.trim();
+  const hasEntries = (await page.getByTestId(/^scoreboard-row-/).count()) > 0;
+  const resetButton = page.getByTestId("manager-reset-round");
+
+  if (stateText === "Preparing" && !hasEntries) {
+    return;
+  }
+
+  if (await resetButton.isVisible()) {
+    page.once("dialog", (dialog) => void dialog.accept());
+    await resetButton.click();
+    await expect(page.getByText("Competition reset. Upload a fresh workbook to start the next dry run.")).toBeVisible();
+    await expect(page.getByTestId("scoreboard-empty-heading")).toBeVisible();
+    await expectCompetitionStateBadge(page, "Preparing");
+    return;
+  }
+
+  throw new Error(`Production proof needs a clean start, but the manager could not reset the current "${stateText ?? "unknown"}" state.`);
+}
+
 async function firstScoreboardRowTop(page: Page, slug: string) {
   return page.getByTestId(`scoreboard-row-${slug}`).first().evaluate((element) => {
     return element.getBoundingClientRect().top;
@@ -235,7 +260,9 @@ async function firstScoreboardRowTop(page: Page, slug: string) {
 }
 
 test.beforeEach(async ({ baseURL }, testInfo) => {
-  await resetCompetitionState();
+  if (baseURL?.includes("localhost") || baseURL?.includes("127.0.0.1")) {
+    await resetCompetitionState();
+  }
   await ensureProofUsers(baseURL!);
   testInfo.setTimeout(180000);
 });
@@ -261,6 +288,12 @@ test("manager, judges, and public users complete the single-screen voting flow",
   const judgePage = await judgeContext.newPage();
   const selfBlockedContext = await createRoleContext(browser, testInfo.project.name);
   const selfBlockedPage = await selfBlockedContext.newPage();
+
+  if (!baseURL?.includes("localhost") && !baseURL?.includes("127.0.0.1")) {
+    await test.step("Manager preflight resets the live board to a clean start", async () => {
+      await ensureManagerCleanStart(managerPage, baseURL!);
+    });
+  }
 
   await test.step("Anonymous visitors can see the board but not manager tools", async () => {
     await anonymousPage.goto("/");


### PR DESCRIPTION
## Summary
- harden immediate post-open voting against remote database consistency lag
- add a reusable production event-day smoke command and recovery-aware proof path
- document the final event-day risk register and manager runbook

## Validation
- pnpm check
- pnpm build
- pnpm exec vitest run tests/votes.integration.test.ts tests/readiness.integration.test.ts --reporter=verbose
- pnpm readiness:public -- --url https://vote.rajeevg.com --concurrency 50 --requests 500
- set -a && source .env.vercel-prod && set +a && pnpm readiness:smoke -- --base-url https://vote.rajeevg.com
- LAYOUT_PROOF=1 E2E_BASE_URL=https://vote.rajeevg.com pnpm exec playwright test tests/e2e/scoreboard-breakpoints.spec.ts --reporter=list

Closes #41